### PR TITLE
feat: add home card with loading animation

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
@@ -9,10 +9,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -52,8 +52,8 @@ fun HomeCard(
 
     Box(
         modifier = modifier
-            .height(210.dp)
-            .width(158.dp)
+            .fillMaxWidth()
+            .aspectRatio(158f / 210f)
             .clip(RoundedCornerShape(12.dp))
             .border(
                 width = 1.dp,
@@ -84,7 +84,7 @@ fun HomeCard(
 }
 
 @Composable
-fun CircularLoadingAnimation(
+private fun CircularLoadingAnimation(
     modifier: Modifier = Modifier,
     color: Color = NovixTheme.colors.secondary
 ) {

--- a/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
@@ -1,0 +1,132 @@
+package com.london.designsystem.component
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import com.london.designsystem.theme.NovixTheme
+import com.london.designsystem.theme.ThemePreviews
+
+@Composable
+fun HomeCard(
+    imageUrl: Any,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isSaved: Boolean = false,
+    imageDescription: String? = null,
+) {
+    var isLoading by remember { mutableStateOf(true) }
+    val imageRequest = ImageRequest.Builder(LocalContext.current)
+        .data(imageUrl)
+        .crossfade(true)
+        .memoryCachePolicy(CachePolicy.ENABLED)
+        .build()
+
+    Box(
+        modifier = modifier
+            .height(210.dp)
+            .width(158.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .border(
+                width = 1.dp,
+                color = NovixTheme.colors.stroke,
+                shape = RoundedCornerShape(12.dp)
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        if (isLoading) {
+            CircularLoadingAnimation(modifier = Modifier.align(Alignment.Center))
+        }
+        AsyncImage(
+            model = imageRequest,
+            contentDescription = imageDescription,
+            modifier = Modifier.matchParentSize(),
+            contentScale = ContentScale.Crop,
+            onSuccess = { isLoading = false },
+            onError = { isLoading = false },
+        )
+        SaveIcon(
+            isSaved = isSaved,
+            onSaveClick = { onSaveClick() },
+            modifier = Modifier
+                .padding(8.dp)
+                .align(Alignment.TopStart)
+        )
+    }
+}
+
+@Composable
+fun CircularLoadingAnimation(
+    modifier: Modifier = Modifier,
+    color: Color = NovixTheme.colors.secondary
+) {
+    val infiniteTransition = rememberInfiniteTransition(label = "circular_loading")
+    val rotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1000, easing = LinearEasing),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "rotation"
+    )
+
+    Canvas(
+        modifier = modifier
+            .size(32.dp)
+            .rotate(rotation)
+    ) {
+        val strokeWidth = 3.dp.toPx()
+
+        drawArc(
+            color = color,
+            startAngle = 0f,
+            sweepAngle = 300f,
+            useCenter = false,
+            style = Stroke(
+                width = strokeWidth,
+                cap = StrokeCap.Round
+            )
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+fun HomeCardPreview() {
+    NovixTheme {
+        HomeCard(
+            imageUrl = "https://image.tmdb.org/t/p/w500/rktDFPbfHfUbArZ6OOOKsXcv0Bm.jpg",
+            isSaved = false,
+            onSaveClick = {}
+        )
+    }
+}

--- a/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
@@ -43,7 +43,7 @@ fun HomeCard(
     isSaved: Boolean = false,
     imageDescription: String? = null,
 ) {
-    var isLoading by remember { mutableStateOf(true) }
+    var isLoading by remember { mutableStateOf(false) }
     val imageRequest = ImageRequest.Builder(LocalContext.current)
         .data(imageUrl)
         .crossfade(true)
@@ -70,6 +70,7 @@ fun HomeCard(
             contentDescription = imageDescription,
             modifier = Modifier.matchParentSize(),
             contentScale = ContentScale.Crop,
+            onLoading = { isLoading = true },
             onSuccess = { isLoading = false },
             onError = { isLoading = false },
         )


### PR DESCRIPTION
### ✅ What does this PR do?  
Adds a loading animation for the `HomeCard` while the image is being fetched to improve the visual feedback during network loading.

---

### ✨ Type of Change  
- [x] ✨ New feature  
- [x] 🎨 UI changes  

---

### 🧩 Changes Made  
- [x] Compose UI  

---

### 🧪 Testing  
- [x] Tested locally  

---

### 🖼️ Screenshots  
> Attached:  
| ✅ Final loaded card image | 🎞️ Loading animation preview |
|---------------------------|------------------------------|
| ![loaded](https://github.com/user-attachments/assets/8f8c00ee-cdfc-4458-a665-57cd4454e1ef) | ![loading](https://github.com/user-attachments/assets/e88b757d-67ef-4d5f-943e-e5e8814b927f) |




---

### 🔍 Notes  
- A circular loading animation was added while waiting for the image to load.  
- The animation uses the `secondary` color from the theme to match the existing UI elements in the screen where the card is displayed, ensuring a consistent and clean look.  
- 
![dark](https://github.com/user-attachments/assets/1de7c143-49d0-4e3e-b0e8-3b131139ba65) ![lightScreen](https://github.com/user-attachments/assets/56153a29-37af-4feb-8ad3-0e4f4c5b4f2d)


---

### ✅ Checklist  
- [x] Code builds without warnings  
- [x] Self-reviewed  
- [x] Ready for review  
