### PR TITLE
Fix/workflow caching

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,8 +41,8 @@ jobs:
         path: |
           ~/.gradle/caches
           ~/.gradle/wrapper
-        key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*') }}
-        restore-keys:
+        key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*', '**/libs.versions.toml') }}
+        restore-keys: |
           gradle-cache-${{ runner.os }}-
           gradle-cache-
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*') }}
+          key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*', '**/libs.versions.toml') }}
           restore-keys: |
             gradle-cache-${{ runner.os }}-
             gradle-cache-
@@ -76,7 +76,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*') }}
+          key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*', '**/libs.versions.toml') }}
           restore-keys: |
             gradle-cache-${{ runner.os }}-
             gradle-cache-


### PR DESCRIPTION
# Fix: Improve Gradle caching strategy to prevent cache bloat

## Problem

GitHub Actions has a 10 GB cache storage limit, and we were experiencing cache inefficiency due to multiple caches with identical keys but different sizes. This occurred because our cache key only included `*.gradle*` files, which don't change when we upgrade dependency versions in `libs.versions.toml`.

## Root Cause

When dependency versions are updated in the version catalog:
- The `*.gradle*` files remain unchanged
- Cache key stays the same
- New cache entries are created with different content
- Old caches aren't properly invalidated

## Solution

Updated the Gradle cache key to include `libs.versions.toml`:

```yaml
key: gradle-cache-${{ hashFiles('**/gradle-wrapper.properties', '**/*.gradle*', '**/settings.gradle*', '**/libs.versions.toml') }}
```

## Benefits

- ✅ **Better cache invalidation**: Version catalog changes now trigger new cache entries
- ✅ **Reduced storage usage**: Prevents accumulation of outdated caches with identical keys
- ✅ **Improved build consistency**: Ensures dependency changes are properly reflected in cached builds
- ✅ **Storage efficiency**: Better utilization of GitHub's 10 GB cache limit

---

*Note: While automated cache cleanup would be ideal, this manual approach provides immediate improvement to our cache management strategy.*