### PR TITLE
refactor: Simplify search logic in SearchViewModel

### DIFF
--- a/presentation/src/main/java/com/london/presentation/screen/search/SearchInteractions.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/search/SearchInteractions.kt
@@ -12,4 +12,16 @@ interface SearchInteractions {
     fun clearRecentSearches()
     fun removeRecentSearch(search: String)
     fun onRecentSearchClick(search: String)
+    fun addToRecentSearches(query: String)
+    fun addToRecentViewed(imageUrl: String)
+    fun clearSearch()
+    fun onApplyFilter(
+        selectedGenres: List<Int>,
+        minimumRating: Int,
+        releaseYearRange: ClosedFloatingPointRange<Float>
+    )
+    fun onClearFilter()
+    fun onReleaseYearRangeChange(range: ClosedFloatingPointRange<Float>)
+    fun onGenreSelectedChange(selectedGenres: List<Int>)
+    fun onRatingChanged(selectedRating: Int)
 }

--- a/presentation/src/main/java/com/london/presentation/screen/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/search/SearchViewModel.kt
@@ -3,7 +3,6 @@ package com.london.presentation.screen.search
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.london.domain.entity.Actor
 import com.london.domain.entity.Movie
 import com.london.domain.entity.TvShow
 import com.london.domain.usecase.GetActorsUseCase
@@ -15,7 +14,6 @@ import com.london.presentation.composables.filterbottomsheet.availableTvGenres
 import com.london.presentation.screen.search.model.MovieUi
 import com.london.presentation.utils.convertGenreCodeToString
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,22 +35,10 @@ class SearchViewModel(
     private val _filterUiState = MutableStateFlow(FilterBottomSheetUiState())
     var filterUiState: StateFlow<FilterBottomSheetUiState> = _filterUiState.asStateFlow()
 
-    private var allMovies: List<Movie> = emptyList()
-    private var allTvShows: List<TvShow> = emptyList()
-    private var allActors: List<Actor> = emptyList()
-
-    private var filteredMovieResults: List<Movie> = emptyList()
-    private var filteredTvShowResults: List<TvShow> = emptyList()
-    private var filteredActorResults: List<Actor> = emptyList()
-
-    private var searchJob: Job? = null
-
     override fun onSearchQueryChange(newValue: TextFieldValue) {
         _uiState.update { it.copy(searchQuery = newValue) }
 
-        searchJob?.cancel()
-
-        searchJob = viewModelScope.launch {
+        viewModelScope.launch {
             delay(300)
             performSearch(newValue.text, _uiState.value.selectedCategory)
         }
@@ -63,17 +49,13 @@ class SearchViewModel(
 
         updateAvailableGenres(category)
 
-        searchJob?.cancel()
-
-        searchJob = viewModelScope.launch {
+        viewModelScope.launch {
             performSearch(_uiState.value.searchQuery.text, category)
         }
     }
 
     override fun onSearchFilterClick(query: String, category: SearchCategory) {
-        searchJob?.cancel()
-
-        searchJob = viewModelScope.launch {
+        viewModelScope.launch {
             performSearch(query, category)
         }
     }
@@ -84,91 +66,82 @@ class SearchViewModel(
         updateAvailableGenres(category)
 
         if (trimmedQuery.isEmpty()) {
-            filteredMovieResults = allMovies
-            filteredTvShowResults = allTvShows
-            filteredActorResults = allActors
-
-            _uiState.update { currentState ->
-                when (category) {
-                    SearchCategory.Movies -> currentState.copy(
-                        movieResults = allMovies,
-                        tvShowUiResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                    SearchCategory.Actors -> currentState.copy(
-                        actorUiResults = allActors,
-                        movieResults = emptyList(),
-                        tvShowUiResults = emptyList()
-                    )
-                    SearchCategory.TvShows -> currentState.copy(
-                        tvShowUiResults = allTvShows,
-                        actorUiResults = emptyList(),
-                        movieResults = emptyList()
-                    )
-                }
-            }
+            clearSearchResults()
             return
         }
 
         searchWithApi(trimmedQuery, category)
     }
 
+    private fun clearSearchResults() {
+        _uiState.update { currentState ->
+            currentState.copy(
+                movieResults = emptyList(),
+                tvShowUiResults = emptyList(),
+                actorUiResults = emptyList()
+            )
+        }
+    }
+
     private fun searchWithApi(query: String, category: SearchCategory) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
                 when (category) {
-                    SearchCategory.Movies -> {
-                        val searchResults = getMoviesUseCase(query, "en-US")
-                        filteredMovieResults = searchResults
-
-                        val filteredResults = applyMovieFilters(searchResults)
-
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                movieResults = filteredResults,
-                                actorUiResults = emptyList(),
-                                tvShowUiResults = emptyList()
-                            )
-                        }
-                    }
-
-                    SearchCategory.Actors -> {
-                        val searchResults = getActorsUseCase(query, "en-US")
-                        filteredActorResults = searchResults
-
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                actorUiResults = searchResults,
-                                movieResults = emptyList(),
-                                tvShowUiResults = emptyList()
-                            )
-                        }
-                    }
-
-                    SearchCategory.TvShows -> {
-                        val searchResults = getTvShowsUseCase(query, "en-US")
-                        filteredTvShowResults = searchResults
-
-                        val filteredResults = applyTvShowFilters(searchResults)
-
-                        _uiState.update { currentState ->
-                            currentState.copy(
-                                tvShowUiResults = filteredResults,
-                                actorUiResults = emptyList(),
-                                movieResults = emptyList()
-                            )
-                        }
-                    }
+                    SearchCategory.Movies -> searchMovies(query)
+                    SearchCategory.Actors -> searchActors(query)
+                    SearchCategory.TvShows -> searchTvShows(query)
                 }
             } catch (e: Exception) {
-                _uiState.update { currentState ->
-                    currentState.copy(
-                        movieResults = emptyList(),
-                        tvShowUiResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                }
+                clearAllSearchResults()
             }
+        }
+    }
+
+    private suspend fun searchMovies(query: String) {
+        val searchResults = getMoviesUseCase(query, "en-US")
+        val filteredResults = applyMovieFilters(searchResults)
+
+        _uiState.update { currentState ->
+            currentState.copy(
+                movieResults = filteredResults,
+                actorUiResults = emptyList(),
+                tvShowUiResults = emptyList()
+            )
+        }
+    }
+
+    private suspend fun searchActors(query: String) {
+        val searchResults = getActorsUseCase(query, "en-US")
+
+        _uiState.update { currentState ->
+            currentState.copy(
+                actorUiResults = searchResults,
+                movieResults = emptyList(),
+                tvShowUiResults = emptyList()
+            )
+        }
+    }
+
+    private suspend fun searchTvShows(query: String) {
+        val searchResults = getTvShowsUseCase(query, "en-US")
+        val filteredResults = applyTvShowFilters(searchResults)
+
+        _uiState.update { currentState ->
+            currentState.copy(
+                tvShowUiResults = filteredResults,
+                actorUiResults = emptyList(),
+                movieResults = emptyList()
+            )
+        }
+    }
+
+    private fun clearAllSearchResults() {
+        _uiState.update { currentState ->
+            currentState.copy(
+                movieResults = emptyList(),
+                tvShowUiResults = emptyList(),
+                actorUiResults = emptyList()
+            )
         }
     }
 
@@ -180,7 +153,8 @@ class SearchViewModel(
 
             val matchesRating = movie.rating >= filterState.imdbRating
 
-            val matchesYear = movie.releaseYear in filterState.releaseYearRange.start.toInt()..filterState.releaseYearRange.endInclusive.toInt()
+            val matchesYear =
+                movie.releaseYear in filterState.releaseYearRange.start.toInt()..filterState.releaseYearRange.endInclusive.toInt()
 
             matchesGenres && matchesRating && matchesYear
         }
@@ -194,7 +168,8 @@ class SearchViewModel(
 
             val matchesRating = tvShow.rating >= filterState.imdbRating
 
-            val matchesYear = tvShow.releaseYear in filterState.releaseYearRange.start.toInt()..filterState.releaseYearRange.endInclusive.toInt()
+            val matchesYear =
+                tvShow.releaseYear in filterState.releaseYearRange.start.toInt()..filterState.releaseYearRange.endInclusive.toInt()
 
             matchesGenres && matchesRating && matchesYear
         }
@@ -212,7 +187,7 @@ class SearchViewModel(
         }
     }
 
-    fun addToRecentSearches(query: String) {
+    override fun addToRecentSearches(query: String) {
         if (query.isBlank()) return
 
         val currentSearches = _uiState.value.recentSearches.toMutableList()
@@ -226,7 +201,7 @@ class SearchViewModel(
         _uiState.update { it.copy(recentSearches = currentSearches) }
     }
 
-    fun addToRecentViewed(imageUrl: String) {
+    override fun addToRecentViewed(imageUrl: String) {
         if (imageUrl.isBlank()) return
 
         val currentViewed = _uiState.value.recentViewed.toMutableList()
@@ -256,22 +231,18 @@ class SearchViewModel(
     override fun onRecentSearchClick(search: String) {
         _uiState.update { it.copy(searchQuery = TextFieldValue(search)) }
 
-        searchJob?.cancel()
-
-        searchJob = viewModelScope.launch {
+        viewModelScope.launch {
             performSearch(search, _uiState.value.selectedCategory)
         }
     }
 
-    fun clearSearch() {
-        searchJob?.cancel()
-
+    override fun clearSearch() {
         _uiState.update {
             it.copy(
                 searchQuery = TextFieldValue(""),
-                movieResults = allMovies,
-                tvShowUiResults = allTvShows,
-                actorUiResults = allActors
+                movieResults = emptyList(),
+                tvShowUiResults = emptyList(),
+                actorUiResults = emptyList()
             )
         }
     }
@@ -295,7 +266,7 @@ class SearchViewModel(
         }
     }
 
-    fun onApplyFilter(
+    override fun onApplyFilter(
         selectedGenres: List<Int>,
         minimumRating: Int,
         releaseYearRange: ClosedFloatingPointRange<Float>
@@ -308,38 +279,12 @@ class SearchViewModel(
             )
         }
 
-        _uiState.update { currentState ->
-            when (currentState.selectedCategory) {
-                SearchCategory.Movies -> {
-                    val filteredMovies = applyMovieFilters(filteredMovieResults)
-                    currentState.copy(
-                        movieResults = filteredMovies,
-                        tvShowUiResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                }
-
-                SearchCategory.TvShows -> {
-                    val filteredTvShows = applyTvShowFilters(filteredTvShowResults)
-                    currentState.copy(
-                        tvShowUiResults = filteredTvShows,
-                        movieResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                }
-
-                SearchCategory.Actors -> {
-                    currentState.copy(
-                        actorUiResults = filteredActorResults,
-                        movieResults = emptyList(),
-                        tvShowUiResults = emptyList()
-                    )
-                }
-            }
+        viewModelScope.launch {
+            performSearch(_uiState.value.searchQuery.text, _uiState.value.selectedCategory)
         }
     }
 
-    fun onClearFilter() {
+    override fun onClearFilter() {
         _filterUiState.update {
             it.copy(
                 selectedGenres = emptyList(),
@@ -348,49 +293,20 @@ class SearchViewModel(
             )
         }
 
-        _uiState.update { currentState ->
-            when (currentState.selectedCategory) {
-                SearchCategory.Movies -> {
-                    currentState.copy(
-                        movieResults = filteredMovieResults,
-                        tvShowUiResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                }
-
-                SearchCategory.TvShows -> {
-                    currentState.copy(
-                        tvShowUiResults = filteredTvShowResults,
-                        movieResults = emptyList(),
-                        actorUiResults = emptyList()
-                    )
-                }
-
-                SearchCategory.Actors -> {
-                    currentState.copy(
-                        actorUiResults = filteredActorResults,
-                        movieResults = emptyList(),
-                        tvShowUiResults = emptyList()
-                    )
-                }
-            }
+        viewModelScope.launch {
+            performSearch(_uiState.value.searchQuery.text, _uiState.value.selectedCategory)
         }
     }
 
-    fun onReleaseYearRangeChange(range: ClosedFloatingPointRange<Float>) {
+    override fun onReleaseYearRangeChange(range: ClosedFloatingPointRange<Float>) {
         _filterUiState.update { it.copy(releaseYearRange = range) }
     }
 
-    fun onGenreSelectedChange(selectedGenres: List<Int>) {
+    override fun onGenreSelectedChange(selectedGenres: List<Int>) {
         _filterUiState.update { it.copy(selectedGenres = selectedGenres) }
     }
 
-    fun onRatingChanged(selectedRating: Int) {
+    override fun onRatingChanged(selectedRating: Int) {
         _filterUiState.update { it.copy(imdbRating = selectedRating) }
-    }
-
-    override fun onCleared() {
-        super.onCleared()
-        searchJob?.cancel()
     }
 }

--- a/presentation/src/main/java/com/london/presentation/screen/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/search/SearchViewModel.kt
@@ -202,6 +202,7 @@ class SearchViewModel(
     }
 
     override fun addToRecentViewed(imageUrl: String) {
+        // (important) make the recent data in the database
         if (imageUrl.isBlank()) return
 
         val currentViewed = _uiState.value.recentViewed.toMutableList()


### PR DESCRIPTION
# What does this PR do?
This PR refactors the search functionality within `SearchViewModel`.

Key changes:
- Removed `searchJob` and its cancellation logic, simplifying coroutine management for search operations.
- Eliminated `allMovies`, `allTvShows`, `allActors`, `filteredMovieResults`, `filteredTvShowResults`, and `filteredActorResults` instance variables. Search results are now directly updated in the UI state.
- Introduced `clearSearchResults()` and `clearAllSearchResults()` helper methods for better code organization.
- Refactored `performSearch` to directly call API search methods or clear results based on query emptiness.
- Individual search methods (`searchMovies`, `searchActors`, `searchTvShows`) are now suspend functions and directly update the UI state.
- Methods previously internal to `SearchViewModel` (`addToRecentSearches`, `addToRecentViewed`, `clearSearch`, filter-related methods) are now exposed through the `SearchInteractions` interface.
- `onApplyFilter` and `onClearFilter` now re-trigger a search with the current query and category to reflect filter changes.
- Removed `onCleared` override as `searchJob` is no longer used.

## Type of Change
- [x] 🔧 Refactoring

## Checklist
- [x] Code builds without warnings
- [x] Tests pass
- [x] Ready for review
