### PR TITLE
Test: Exclude domain entities from coverage reports

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ kover {
                 }
                 excludes{
                     classes("*.Exceptions.*")
+                    classes("com.london.domain.entity.**")
                 }
             }
             verify {


### PR DESCRIPTION
# What does this PR do?
This PR is excluding the domain entities from the test report

