### PR TITLE
fix/details-screens

### DIFF
--- a/app/src/main/java/com/london/app/navigation/NovixApp.kt
+++ b/app/src/main/java/com/london/app/navigation/NovixApp.kt
@@ -30,9 +30,9 @@ import com.london.presentation.screen.account.AccountScreen
 import com.london.presentation.screen.bookmark.BookmarksScreen
 import com.london.presentation.screen.category.CategoriesScreen
 import com.london.presentation.screen.details.actordetails.topmoviespicks.TopMoviesPicksScreen
+import com.london.presentation.screen.details.movieDetalis.MovieDetailsScreen
 import com.london.presentation.screen.details.tvshow.tvshowdetails.TvShowsDetailsScreen
 import com.london.presentation.screen.home.HomeScreen
-import com.london.presentation.screen.moiveDetalis.MovieDetailsScreen
 import com.london.presentation.screen.search.SearchScreen
 
 @Composable

--- a/designSystem/src/main/java/com/london/designsystem/component/ButtonIcon.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/ButtonIcon.kt
@@ -22,25 +22,26 @@ fun ButtonIcon(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     iconRes: Int,
-    backgroundColor: Color = NovixTheme.colors.iconBackground
+    backgroundColor: Color = NovixTheme.colors.iconBackground,
+    tint: Color = NovixTheme.colors.onPrimary
 ) {
     Box(
         modifier = modifier
             .size(32.dp)
-            .clip(RoundedCornerShape(12.dp))
-            .background(color = backgroundColor)
             .border(
                 width = 1.dp, color = NovixTheme.colors.stroke, shape = RoundedCornerShape(8.dp)
             )
+            .clip(RoundedCornerShape(12.dp))
+            .background(color = backgroundColor)
             .padding(6.dp)
-            .noRippleClickable (
+            .noRippleClickable(
                 onClick
             ), contentAlignment = Alignment.Center
     ) {
         Icon(
             painter = painterResource(iconRes),
             contentDescription = "icon",
-            tint = NovixTheme.colors.onPrimary,
+            tint = tint,
             modifier = Modifier
         )
     }

--- a/designSystem/src/main/java/com/london/designsystem/component/SaveIcon.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/SaveIcon.kt
@@ -32,7 +32,8 @@ fun SaveIcon(
     isSaved: Boolean,
     onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
-    backgroundColor: Color = NovixTheme.colors.iconBackground
+    backgroundColor: Color = NovixTheme.colors.iconBackground,
+    tint: Color = NovixTheme.colors.onPrimary,
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = if (isSaved) 1f else 0f,
@@ -41,7 +42,7 @@ fun SaveIcon(
             stiffness = 100f
         )
     )
-    Box (
+    Box(
         modifier = modifier
             .size(32.dp)
             .clip(RoundedCornerShape(8.dp))
@@ -59,7 +60,7 @@ fun SaveIcon(
         Icon(
             painter = painterResource(R.drawable.icon_remove),
             contentDescription = "Not Save",
-            tint = NovixTheme.colors.onPrimary,
+            tint = tint,
             modifier = Modifier
                 .align(Alignment.Center)
                 .scale(1f - animatedProgress)
@@ -69,7 +70,7 @@ fun SaveIcon(
         Icon(
             painter = painterResource(R.drawable.icon_save),
             contentDescription = "Save",
-            tint = NovixTheme.colors.onPrimary,
+            tint = tint,
             modifier = Modifier
                 .scale(animatedProgress)
                 .alpha(animatedProgress)

--- a/presentation/src/main/java/com/london/presentation/composables/ConditionalText.kt
+++ b/presentation/src/main/java/com/london/presentation/composables/ConditionalText.kt
@@ -1,0 +1,78 @@
+package com.london.presentation.composables
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.london.designsystem.R
+import com.london.designsystem.theme.NovixTheme
+
+@Composable
+fun ConditionalText(
+    text: String,
+    expandedState: Boolean,
+    onExpandedChange: () -> Unit
+) {
+    val minimumLineLength = 3
+    var showReadMoreButtonState by remember { mutableStateOf(false) }
+    var truncatedText by remember { mutableStateOf("") }
+
+    val textStyle = NovixTheme.typography.body.small.copy(color = NovixTheme.colors.body)
+    val actionStyle = SpanStyle(
+        color = NovixTheme.colors.primary,
+        fontSize = NovixTheme.typography.label.medium.fontSize,
+        fontWeight = NovixTheme.typography.label.medium.fontWeight
+    )
+
+    Text(
+        text = buildAnnotatedString {
+            when {
+                !showReadMoreButtonState -> append(text)
+                !expandedState -> {
+                    append(truncatedText)
+                    withStyle(actionStyle) { append(stringResource(R.string.read_more)) }
+                }
+
+                else -> {
+                    append(text)
+                    withStyle(actionStyle) { append(stringResource(R.string.read_less)) }
+                }
+            }
+        },
+        style = textStyle,
+        maxLines = if (expandedState || !showReadMoreButtonState) Int.MAX_VALUE else minimumLineLength,
+        onTextLayout = { textLayoutResult ->
+            if (!showReadMoreButtonState && textLayoutResult.lineCount > minimumLineLength) {
+                val lastVisibleLineEndIndex = textLayoutResult.getLineEnd(minimumLineLength - 1)
+                val readMoreLength = 15
+                var truncateIndex = maxOf(0, lastVisibleLineEndIndex - readMoreLength)
+
+                while (truncateIndex > 0 && text[truncateIndex] != ' ') {
+                    truncateIndex--
+                }
+
+                truncatedText = text.substring(0, truncateIndex).trim()
+                showReadMoreButtonState = true
+            }
+        },
+        modifier = Modifier
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) {
+                if (showReadMoreButtonState) onExpandedChange()
+            }
+    )
+}

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsIntersection.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsIntersection.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.screen.moiveDetalis
+package com.london.presentation.screen.details.movieDetalis
 
 interface MovieDetailsIntersection {
     fun onSavedClick()

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.screen.moiveDetalis
+package com.london.presentation.screen.details.movieDetalis
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -6,8 +6,6 @@ import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -39,7 +37,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -47,9 +44,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.times
@@ -74,6 +68,7 @@ import com.london.presentation.R.string.separator
 import com.london.presentation.R.string.star
 import com.london.presentation.R.string.time_icon
 import com.london.presentation.R.string.view_reviews
+import com.london.presentation.composables.ConditionalText
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -193,21 +188,24 @@ fun MovieDetailsContent(
                     }
                 }
             }
-            Text(
-                stringResource(overview),
-                style = NovixTheme.typography.label.large,
-                color = NovixTheme.colors.title,
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp)
+            if (state.movieOverview.isNotBlank()) {
+                Text(
+                    text = stringResource(overview),
+                    style = NovixTheme.typography.title.medium,
+                    color = NovixTheme.colors.title,
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
+                )
 
-            )
-            ConditionalText(
-                state.movieOverview, state.expanded, onExpandClick
-            )
+                ConditionalText(
+                    state.movieOverview, state.expanded, onExpandClick
+                )
+            }
+
             Text(
                 stringResource(com.london.presentation.R.string.cast),
                 style = NovixTheme.typography.title.medium,
                 color = NovixTheme.colors.title,
-                modifier = Modifier.padding(start = 16.dp)
+                modifier = Modifier.padding(start = 16.dp, top = 16.dp)
             )
             LazyHorizontalGrid(
                 modifier = Modifier
@@ -437,65 +435,6 @@ private fun MovieDetailsImage(
                 .align(Alignment.TopStart)
         )
     }
-}
-
-@Composable
-private fun ConditionalText(
-    text: String,
-    expandedState: Boolean,
-    onExpandedChange: () -> Unit
-) {
-    val minimumLineLength = 3
-    var showReadMoreButtonState by remember { mutableStateOf(false) }
-    var truncatedText by remember { mutableStateOf("") }
-
-    val textStyle = NovixTheme.typography.body.small.copy(color = NovixTheme.colors.body)
-    val actionStyle = SpanStyle(
-        color = NovixTheme.colors.primary,
-        fontSize = NovixTheme.typography.label.medium.fontSize,
-        fontWeight = NovixTheme.typography.label.medium.fontWeight
-    )
-
-    Text(
-        text = buildAnnotatedString {
-            when {
-                !showReadMoreButtonState -> append(text)
-                !expandedState -> {
-                    append(truncatedText)
-                    withStyle(actionStyle) { append(stringResource(R.string.read_more)) }
-                }
-
-                else -> {
-                    append(text)
-                    withStyle(actionStyle) { append(stringResource(R.string.read_less)) }
-                }
-            }
-        },
-        style = textStyle,
-        maxLines = if (expandedState || !showReadMoreButtonState) Int.MAX_VALUE else minimumLineLength,
-        onTextLayout = { textLayoutResult ->
-            if (!showReadMoreButtonState && textLayoutResult.lineCount > minimumLineLength) {
-                val lastVisibleLineEndIndex = textLayoutResult.getLineEnd(minimumLineLength - 1)
-                val readMoreLength = 15
-                var truncateIndex = maxOf(0, lastVisibleLineEndIndex - readMoreLength)
-
-                while (truncateIndex > 0 && text[truncateIndex] != ' ') {
-                    truncateIndex--
-                }
-
-                truncatedText = text.substring(0, truncateIndex).trim()
-                showReadMoreButtonState = true
-            }
-        },
-        modifier = Modifier
-            .padding(horizontal = 16.dp, vertical = 4.dp)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null
-            ) {
-                if (showReadMoreButtonState) onExpandedChange()
-            }
-    )
 }
 
 @Preview(showBackground = true)

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,20 +22,22 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -46,7 +50,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.times
+import androidx.compose.ui.zIndex
 import com.london.designsystem.R
 import com.london.designsystem.component.ActorItem
 import com.london.designsystem.component.ButtonIcon
@@ -112,145 +116,214 @@ fun MovieDetailsContent(
     onBackClick: () -> Unit,
     onPreviewClick: (Int) -> Unit
 ) {
+    val lazyState = rememberLazyListState()
+    val isScrolledFarEnough = remember {
+        derivedStateOf {
+            lazyState.firstVisibleItemIndex > 0 || lazyState.firstVisibleItemScrollOffset > 500
+        }
+    }
+    val iconTint = if (isScrolledFarEnough.value) NovixTheme.colors.title else Color.White
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(NovixTheme.colors.surface)
     ) {
-        Column(
+
+        Box(
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+                .fillMaxWidth()
+                .align(Alignment.TopCenter)
+                .zIndex(1.0f)
+                .background(if (isScrolledFarEnough.value) NovixTheme.colors.surface else Color.Transparent)
+                .padding(
+                    top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+                ),
+            contentAlignment = Alignment.Center
         ) {
-            Box(
+
+            SaveIcon(
+                isSaved = state.isSaved,
+                onSaveClick = {
+                    // TODO
+                },
+                backgroundColor = NovixTheme.colors.iconBackgroundLow,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .defaultMinSize(minHeight = 370.dp)
-            ) {
-                MovieDetailsImage(
-                    isSaved = state.isSaved,
-                    onSaveClick = {
-                        //TODO("Not yet implemented")
-                    },
-                    images = state.movieImage,
-                    currentImageIndex = state.currentImageIndex,
-                    direction = state.imageSlideDirection,
-                    onBackClick = onBackClick
-                )
-                Column(
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(16))
+                    .align(Alignment.TopEnd),
+                tint = iconTint
+            )
+
+            ButtonIcon(
+                onClick = onBackClick,
+                iconRes = R.drawable.arrow_left,
+                backgroundColor = NovixTheme.colors.iconBackgroundLow,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .size(40.dp)
+                    .clip(RoundedCornerShape(16))
+                    .align(Alignment.TopStart),
+                tint = iconTint
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(bottom = 100.dp),
+            state = lazyState
+        ) {
+            item {
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .align(Alignment.BottomCenter),
-                    verticalArrangement = Arrangement.spacedBy(4.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally
+                        .defaultMinSize(minHeight = 370.dp)
+
                 ) {
-                    NovixCarousalRow(
-                        dotsStates = List(state.movieImage.size) { index -> index == state.currentImageIndex },
-                        modifier = Modifier
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(NovixTheme.colors.iconBackgroundLow)
-                            .border(1.dp, NovixTheme.colors.stroke, RoundedCornerShape(12.dp))
-                            .padding(horizontal = 12.dp, vertical = 4.dp)
+                    MovieDetailsImage(
+                        images = state.movieImage,
+                        currentImageIndex = state.currentImageIndex,
+                        direction = state.imageSlideDirection,
                     )
 
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .defaultMinSize(minHeight = 158.dp)
-                            .padding(horizontal = 16.dp)
-                            .clip(RoundedCornerShape(12.dp))
-                            .background(NovixTheme.colors.surface)
-                            .border(1.dp, NovixTheme.colors.stroke, RoundedCornerShape(12.dp))
-                            .padding(12.dp), verticalArrangement = Arrangement.spacedBy(8.dp)
+                            .align(Alignment.BottomCenter),
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
                     ) {
+                        NovixCarousalRow(
+                            dotsStates = List(state.movieImage.size) { index ->
+                                index == state.currentImageIndex
+                            },
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(NovixTheme.colors.iconBackgroundLow)
+                                .border(1.dp, NovixTheme.colors.stroke, RoundedCornerShape(12.dp))
+                                .padding(horizontal = 12.dp, vertical = 4.dp)
+                        )
 
-                        Text(
-                            state.movieName,
-                            style = NovixTheme.typography.title.medium,
-                            color = NovixTheme.colors.title,
-                            modifier = Modifier.defaultMinSize(minHeight = 56.dp)
-                        )
-                        GenreRow(state.movieGenres)
-                        RatingAndMetaRow(
-                            rate = state.movieRating,
-                            time = state.movieDuration,
-                            date = state.releaseDate
-                        )
-                        Text(
-                            stringResource(view_reviews),
-                            style = NovixTheme.typography.label.medium,
-                            color = NovixTheme.colors.primary,
-                            modifier = Modifier.noRippleClickable {
-                                onPreviewClick(state.movieId)
-                            }
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .defaultMinSize(minHeight = 158.dp)
+                                .padding(horizontal = 16.dp)
+                                .clip(RoundedCornerShape(12.dp))
+                                .background(NovixTheme.colors.surface)
+                                .border(1.dp, NovixTheme.colors.stroke, RoundedCornerShape(12.dp))
+                                .padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            Text(
+                                text = state.movieName,
+                                style = NovixTheme.typography.title.medium,
+                                color = NovixTheme.colors.title,
+                                modifier = Modifier.defaultMinSize(minHeight = 56.dp)
+                            )
+                            GenreRow(state.movieGenres)
+                            RatingAndMetaRow(
+                                rate = state.movieRating,
+                                time = state.movieDuration,
+                                date = state.releaseDate
+                            )
+                            Text(
+                                text = stringResource(view_reviews),
+                                style = NovixTheme.typography.label.medium,
+                                color = NovixTheme.colors.primary,
+                                modifier = Modifier.noRippleClickable {
+                                    onPreviewClick(state.movieId)
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (state.movieOverview.isNotBlank()) {
+                item {
+                    Text(
+                        text = stringResource(overview),
+                        style = NovixTheme.typography.title.medium,
+                        color = NovixTheme.colors.title,
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
+                    )
+                }
+
+                item {
+                    ConditionalText(
+                        state.movieOverview,
+                        state.expanded,
+                        onExpandClick
+                    )
+                }
+            }
+
+            item {
+                Text(
+                    text = stringResource(com.london.presentation.R.string.cast),
+                    style = NovixTheme.typography.title.medium,
+                    color = NovixTheme.colors.title,
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp)
+                )
+            }
+
+            item {
+                LazyHorizontalGrid(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    rows = GridCells.Fixed(1),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp)
+                ) {
+                    items(state.genres) { actor ->
+                        ActorItem(
+                            actorName = actor.name,
+                            characterName = actor.characterName,
+                            imageRes = actor.avatarUrl,
+                            modifier = Modifier.defaultMinSize(minWidth = 375.dp)
                         )
                     }
                 }
             }
-            if (state.movieOverview.isNotBlank()) {
+
+            item {
                 Text(
-                    text = stringResource(overview),
+                    text = stringResource(more_like_this),
                     style = NovixTheme.typography.title.medium,
                     color = NovixTheme.colors.title,
-                    modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
-                )
-
-                ConditionalText(
-                    state.movieOverview, state.expanded, onExpandClick
+                    modifier = Modifier.padding(start = 16.dp, top = 16.dp)
                 )
             }
 
-            Text(
-                stringResource(com.london.presentation.R.string.cast),
-                style = NovixTheme.typography.title.medium,
-                color = NovixTheme.colors.title,
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp)
-            )
-            LazyHorizontalGrid(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(100.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp),
-                rows = GridCells.Fixed(1),
-            ) {
-                items(state.genres) { actor ->
-                    ActorItem(
-                        actorName = actor.name,
-                        characterName = actor.characterName,
-                        imageRes = actor.avatarUrl,
-                        modifier = Modifier.defaultMinSize(minWidth = 375.dp)
-                    )
-                }
-            }
-
-            Text(
-                stringResource(more_like_this),
-                style = NovixTheme.typography.title.medium,
-                color = NovixTheme.colors.title,
-                modifier = Modifier.padding(start = 16.dp, top = 16.dp)
-            )
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                modifier = Modifier
-                    .padding(horizontal = 16.dp)
-                    .height((state.similarMovies.size / 2 + state.similarMovies.size % 2) * 220.dp),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                userScrollEnabled = false,
-            ) {
-                items(state.similarMovies) { movie ->
-                    HomeCard(
-                        imageUrl = movie.image,
-                        isSaved = movie.isSaved,
-                        onSaveClick = {
-                            //TODO("Not yet implemented")
-                        }
-                    )
+            items(state.similarMovies.chunked(2)) { rowItems ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    rowItems.forEach { movie ->
+                        HomeCard(
+                            imageUrl = movie.image,
+                            isSaved = movie.isSaved,
+                            onSaveClick = {
+                                // TODO
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                        )
+                    }
+                    if (rowItems.size == 1) {
+                        Spacer(modifier = Modifier.weight(1f)) // fill empty space if odd item count
+                    }
                 }
             }
         }
+
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -259,7 +332,7 @@ fun MovieDetailsContent(
                 .windowInsetsPadding(WindowInsets.navigationBars),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            if (state.movieHaveTrailer.not()) {
+            if (!state.movieHaveTrailer) {
                 PrimaryButton(
                     text = null,
                     onClick = {},
@@ -270,21 +343,23 @@ fun MovieDetailsContent(
                     isDisabled = false,
                 )
             }
+
             PrimaryButton(
                 text = stringResource(play_trailer),
                 onClick = {
-                    //TODO("Not yet implemented")
+                    // TODO
                 },
                 hasLabel = true,
                 hasIcon = false,
                 isLoading = false,
-                isDisabled = state.movieHaveTrailer.not(),
+                isDisabled = !state.movieHaveTrailer,
                 icon = null,
                 modifier = Modifier.weight(1f)
             )
         }
     }
 }
+
 
 @Composable
 private fun RatingAndMetaRow(
@@ -374,14 +449,11 @@ private fun Dot(modifier: Modifier = Modifier) {
 @Composable
 private fun MovieDetailsImage(
     images: List<Any>,
-    onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isSaved: Boolean = false,
     imageDescription: String? = null,
     loadingState: MutableState<Boolean> = remember { mutableStateOf(false) },
     currentImageIndex: Int,
     direction: Int,
-    onBackClick: () -> Unit
 ) {
     Box(
         modifier = modifier
@@ -412,28 +484,6 @@ private fun MovieDetailsImage(
                 )
             }
         }
-
-        SaveIcon(
-            isSaved = isSaved,
-            onSaveClick = onSaveClick,
-            backgroundColor = NovixTheme.colors.iconBackgroundLow,
-            modifier = Modifier
-                .padding(16.dp)
-                .size(40.dp)
-                .clip(RoundedCornerShape(16))
-                .align(Alignment.TopEnd)
-        )
-
-        ButtonIcon(
-            onClick = onBackClick,
-            iconRes = R.drawable.arrow_left,
-            backgroundColor = NovixTheme.colors.iconBackgroundLow,
-            modifier = Modifier
-                .padding(16.dp)
-                .size(40.dp)
-                .clip(RoundedCornerShape(16))
-                .align(Alignment.TopStart)
-        )
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsUiState.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.screen.moiveDetalis
+package com.london.presentation.screen.details.movieDetalis
 
 data class MovieDetailsUiState(
     val movieId: Int = 0,

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsViewModel.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.screen.moiveDetalis
+package com.london.presentation.screen.details.movieDetalis
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/mapper.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/mapper.kt
@@ -1,8 +1,8 @@
-package com.london.presentation.screen.moiveDetalis
+package com.london.presentation.screen.details.movieDetalis
 
-import com.london.domain.entity.moviedatails.MovieDetails
 import com.london.domain.entity.Actor
 import com.london.domain.entity.moviedatails.Genre
+import com.london.domain.entity.moviedatails.MovieDetails
 import com.london.domain.entity.moviedatails.SimilarMovie
 
 fun mapToUiState(

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -62,6 +62,7 @@ import com.london.presentation.composables.ConditionalText
 import com.london.presentation.utils.toLocalizedNumbers
 import org.koin.androidx.compose.koinViewModel
 
+
 @Composable
 fun TvShowsDetailsScreen(
     viewModel: TvShowDetailsViewModel = koinViewModel(),
@@ -147,7 +148,7 @@ fun TvShowsDetailScreenContent(
                         text = stringResource(overview),
                         style = NovixTheme.typography.label.large,
                         color = NovixTheme.colors.title,
-                        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp)
                     )
 
                     ConditionalText(

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -44,6 +45,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.ae.imageharamblur.ui.ImageViewFilter
@@ -57,8 +59,6 @@ import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.tvshowdetails.ImageItemEntity
 import com.london.domain.entity.tvshowdetails.TvShowCastMemberEntity
-import com.london.presentation.R.string.overview
-import com.london.presentation.composables.ConditionalText
 import com.london.presentation.utils.toLocalizedNumbers
 import org.koin.androidx.compose.koinViewModel
 
@@ -70,7 +70,7 @@ fun TvShowsDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     TvShowsDetailScreenContent(
-        uiState = uiState, onExpandClick = viewModel::onExpandClick,
+        uiState = uiState,
         onBackClick = onBackClick
     )
 }
@@ -79,7 +79,6 @@ fun TvShowsDetailsScreen(
 fun TvShowsDetailScreenContent(
     modifier: Modifier = Modifier,
     uiState: TvShowDetailsUiState,
-    onExpandClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
     Box(
@@ -143,18 +142,14 @@ fun TvShowsDetailScreenContent(
             }
 
             item {
-                if (uiState.overview.isNotBlank()) {
-                    Text(
-                        text = stringResource(overview),
-                        style = NovixTheme.typography.label.large,
-                        color = NovixTheme.colors.title,
-                        modifier = Modifier.padding(start = 16.dp, top = 16.dp)
+                OverviewSection(
+                    uiState = uiState,
+                    modifier = Modifier.padding(
+                        top = 16.dp,
+                        start = 16.dp,
+                        end = 16.dp
                     )
-
-                    ConditionalText(
-                        uiState.overview, uiState.expanded, onExpandClick
-                    )
-                }
+                )
             }
 
             item {
@@ -453,6 +448,46 @@ fun TvShowRating(
             style = NovixTheme.typography.label.small,
             color = NovixTheme.colors.title
         )
+    }
+}
+
+@Composable
+fun OverviewSection(
+    modifier: Modifier = Modifier,
+    uiState: TvShowDetailsUiState
+) {
+    var maxLines by rememberSaveable { mutableIntStateOf(4) }
+    var isTextCollapsed by rememberSaveable { mutableStateOf(false) }
+    Column(
+        modifier = modifier
+    ) {
+        Text(
+            text = stringResource(R.string.overview),
+            style = NovixTheme.typography.title.medium,
+            color = NovixTheme.colors.title
+        )
+
+        Column {
+            Text(
+                text = uiState.overview,
+                style = NovixTheme.typography.body.small,
+                color = NovixTheme.colors.body,
+                maxLines = maxLines,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = if (isTextCollapsed)
+                    stringResource(R.string.read_less) else stringResource(R.string.read_more),
+                style = NovixTheme.typography.body.small,
+                color = NovixTheme.colors.primary,
+                modifier = Modifier
+                    .clickable {
+                        maxLines = if (maxLines == 4) Int.MAX_VALUE else 4
+                        isTextCollapsed = !isTextCollapsed
+                    }
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -34,7 +34,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -45,7 +44,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.ae.imageharamblur.ui.ImageViewFilter
@@ -59,9 +57,10 @@ import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.tvshowdetails.ImageItemEntity
 import com.london.domain.entity.tvshowdetails.TvShowCastMemberEntity
+import com.london.presentation.R.string.overview
+import com.london.presentation.composables.ConditionalText
 import com.london.presentation.utils.toLocalizedNumbers
 import org.koin.androidx.compose.koinViewModel
-
 
 @Composable
 fun TvShowsDetailsScreen(
@@ -70,7 +69,7 @@ fun TvShowsDetailsScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     TvShowsDetailScreenContent(
-        uiState = uiState,
+        uiState = uiState, onExpandClick = viewModel::onExpandClick,
         onBackClick = onBackClick
     )
 }
@@ -79,6 +78,7 @@ fun TvShowsDetailsScreen(
 fun TvShowsDetailScreenContent(
     modifier: Modifier = Modifier,
     uiState: TvShowDetailsUiState,
+    onExpandClick: () -> Unit,
     onBackClick: () -> Unit
 ) {
     Box(
@@ -142,14 +142,18 @@ fun TvShowsDetailScreenContent(
             }
 
             item {
-                OverviewSection(
-                    uiState = uiState,
-                    modifier = Modifier.padding(
-                        top = 16.dp,
-                        start = 16.dp,
-                        end = 16.dp
+                if (uiState.overview.isNotBlank()) {
+                    Text(
+                        text = stringResource(overview),
+                        style = NovixTheme.typography.label.large,
+                        color = NovixTheme.colors.title,
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 4.dp)
                     )
-                )
+
+                    ConditionalText(
+                        uiState.overview, uiState.expanded, onExpandClick
+                    )
+                }
             }
 
             item {
@@ -448,46 +452,6 @@ fun TvShowRating(
             style = NovixTheme.typography.label.small,
             color = NovixTheme.colors.title
         )
-    }
-}
-
-@Composable
-fun OverviewSection(
-    modifier: Modifier = Modifier,
-    uiState: TvShowDetailsUiState
-) {
-    var maxLines by rememberSaveable { mutableIntStateOf(4) }
-    var isTextCollapsed by rememberSaveable { mutableStateOf(false) }
-    Column(
-        modifier = modifier
-    ) {
-        Text(
-            text = stringResource(R.string.overview),
-            style = NovixTheme.typography.title.medium,
-            color = NovixTheme.colors.title
-        )
-
-        Column {
-            Text(
-                text = uiState.overview,
-                style = NovixTheme.typography.body.small,
-                color = NovixTheme.colors.body,
-                maxLines = maxLines,
-                overflow = TextOverflow.Ellipsis
-            )
-
-            Text(
-                text = if (isTextCollapsed)
-                    stringResource(R.string.read_less) else stringResource(R.string.read_more),
-                style = NovixTheme.typography.body.small,
-                color = NovixTheme.colors.primary,
-                modifier = Modifier
-                    .clickable {
-                        maxLines = if (maxLines == 4) Int.MAX_VALUE else 4
-                        isTextCollapsed = !isTextCollapsed
-                    }
-            )
-        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsUiState.kt
@@ -1,17 +1,17 @@
 package com.london.presentation.screen.details.tvshow.tvshowdetails
 
-import com.london.domain.entity.tvshowdetails.TvShowCastEntity
 import com.london.domain.entity.tvshowdetails.ImageItemEntity
+import com.london.domain.entity.tvshowdetails.TvShowCastEntity
 import com.london.domain.entity.tvshowdetails.TvShowCreatorEntity
-import com.london.domain.entity.tvshowdetails.episode.TvShowEpisodeBySeasonEntity
 import com.london.domain.entity.tvshowdetails.TvShowEpisodeEntity
-import com.london.domain.entity.tvshowdetails.episode.TvShowEpisodesEntity
 import com.london.domain.entity.tvshowdetails.TvShowGenreEntity
 import com.london.domain.entity.tvshowdetails.TvShowNetworkEntity
 import com.london.domain.entity.tvshowdetails.TvShowProductionCompanyEntity
 import com.london.domain.entity.tvshowdetails.TvShowProductionCountryEntity
 import com.london.domain.entity.tvshowdetails.TvShowSeasonEntity
 import com.london.domain.entity.tvshowdetails.TvShowSpokenLanguageEntity
+import com.london.domain.entity.tvshowdetails.episode.TvShowEpisodeBySeasonEntity
+import com.london.domain.entity.tvshowdetails.episode.TvShowEpisodesEntity
 
 data class TvShowDetailsUiState(
     val tvImages: List<ImageItemEntity>? = listOf(),
@@ -49,5 +49,6 @@ data class TvShowDetailsUiState(
     val tagline: String = "",
     val type: String = "",
     val voteAverage: Double = 0.0,
-    val voteCount: Int = 0
+    val voteCount: Int = 0,
+    val expanded: Boolean = false,
 )

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsUiState.kt
@@ -50,5 +50,4 @@ data class TvShowDetailsUiState(
     val type: String = "",
     val voteAverage: Double = 0.0,
     val voteCount: Int = 0,
-    val expanded: Boolean = false,
 )

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
@@ -50,6 +50,10 @@ class TvShowDetailsViewModel(
         }
     }
 
+    fun onExpandClick() {
+        _uiState.value = _uiState.value.copy(expanded = !_uiState.value.expanded)
+    }
+
     private fun getImagesData() {
         viewModelScope.launch {
             val images = getTvShowImages(tvShowId)

--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
@@ -50,10 +50,6 @@ class TvShowDetailsViewModel(
         }
     }
 
-    fun onExpandClick() {
-        _uiState.value = _uiState.value.copy(expanded = !_uiState.value.expanded)
-    }
-
     private fun getImagesData() {
         viewModelScope.launch {
             val images = getTvShowImages(tvShowId)


### PR DESCRIPTION
# What does this PR do?

This commit refactors the file structure and naming for movie details related files.
- Renamed `TvShowDetails.kt` to `TvShowDetailsScreen.kt`.
- Moved movie details files to a new `details/movieDetalis` package.
- Renamed the `moiveDetalis` package to `details/movieDetalis`.
- Introduced a reusable `ConditionalText` composable for handling expandable text.
- Integrated `ConditionalText` into `MovieDetailsScreen` and `TvShowDetailsScreen` to replace previous custom implementations for "Read More/Less" functionality.

- Adjusted padding and styling for overview and cast sections in `MovieDetailsScreen` and `TvShowDetailsScreen`.

- **Implementing a `LazyColumn` for the main content:** This improves scrolling performance, especially for longer content.
- **Making the save and back icons sticky at the top:** These icons now remain visible as the user scrolls.
- **Dynamically changing icon tint and background:** The save and back icons' tint and background color now adjust based on the scroll position, providing better visual feedback.
- **Introducing `tint` parameter to `ButtonIcon` and `SaveIcon`:** This allows for more flexible icon styling.
- **Adjusting similar movies layout:** Similar movies are now displayed in a more conventional row-based layout within the `LazyColumn`.