### PR TITLE
Refactor: Standardize icon tint and conditionally show sections in MovieDetailsScreen, issue #26

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/ButtonIcon.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/ButtonIcon.kt
@@ -23,7 +23,6 @@ fun ButtonIcon(
     modifier: Modifier = Modifier,
     iconRes: Int,
     backgroundColor: Color = NovixTheme.colors.iconBackground,
-    tint: Color = NovixTheme.colors.onPrimary
 ) {
     Box(
         modifier = modifier
@@ -41,7 +40,7 @@ fun ButtonIcon(
         Icon(
             painter = painterResource(iconRes),
             contentDescription = "icon",
-            tint = tint,
+            tint = NovixTheme.colors.title,
             modifier = Modifier
         )
     }

--- a/designSystem/src/main/java/com/london/designsystem/component/SaveIcon.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/SaveIcon.kt
@@ -33,7 +33,6 @@ fun SaveIcon(
     onSaveClick: () -> Unit,
     modifier: Modifier = Modifier,
     backgroundColor: Color = NovixTheme.colors.iconBackground,
-    tint: Color = NovixTheme.colors.onPrimary,
 ) {
     val animatedProgress by animateFloatAsState(
         targetValue = if (isSaved) 1f else 0f,
@@ -60,7 +59,7 @@ fun SaveIcon(
         Icon(
             painter = painterResource(R.drawable.icon_remove),
             contentDescription = "Not Save",
-            tint = tint,
+            tint = NovixTheme.colors.title,
             modifier = Modifier
                 .align(Alignment.Center)
                 .scale(1f - animatedProgress)
@@ -70,7 +69,7 @@ fun SaveIcon(
         Icon(
             painter = painterResource(R.drawable.icon_save),
             contentDescription = "Save",
-            tint = tint,
+            tint = NovixTheme.colors.title,
             modifier = Modifier
                 .scale(animatedProgress)
                 .alpha(animatedProgress)

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -257,7 +257,7 @@ fun MovieDetailsContent(
                 }
             }
 
-            if (state.genres.isNotEmpty()) {
+            if (state.actors.isNotEmpty()) {
                 item {
                     Text(
                         text = stringResource(com.london.presentation.R.string.cast),
@@ -274,12 +274,12 @@ fun MovieDetailsContent(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp)
                     ) {
-                        items(state.genres) { actor ->
+                        items(state.actors) { actor ->
                             ActorItem(
                                 actorName = actor.name,
                                 characterName = actor.characterName,
                                 imageRes = actor.avatarUrl,
-                                modifier = Modifier.defaultMinSize(minWidth = 375.dp)
+                                modifier = Modifier.defaultMinSize(minWidth = 296.dp)
                             )
                         }
                     }
@@ -503,7 +503,7 @@ private fun MovieDetailsPreview() {
         movieDuration = "2h 22m",
         releaseDate = "1994-09-22",
         movieOverview = "It is a 1994 American drama film, considered one of the greatest films in cinematic history. It revolves around Andy Dufresne, a banker wrongfully convicted of the murder of his wife and",
-        genres = listOf(
+        actors = listOf(
             ActorUIState(
                 "Tim Robbins",
                 characterName = "Andy Dufresne",

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -359,40 +359,56 @@ fun MovieDetailsContent(
     }
 }
 
-
 @Composable
 private fun RatingAndMetaRow(
-    rate: String,
-    time: String,
-    date: String,
+    rate: String?,
+    time: String?,
+    date: String?,
 ) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        IconWithText(
-            icon = drawable.star,
-            contentDesc = stringResource(star),
-            tint = NovixTheme.colors.yellowAccent,
-            text = rate,
-            textColor = NovixTheme.colors.title
-        )
-        Dot()
-        IconWithText(
-            icon = drawable.time_04,
-            contentDesc = stringResource(time_icon),
-            tint = NovixTheme.colors.body,
-            text = time,
-            textColor = NovixTheme.colors.body
-        )
-        Dot()
-        IconWithText(
-            icon = drawable.calendar_03,
-            contentDesc = stringResource(calendar),
-            tint = NovixTheme.colors.body,
-            text = date,
-            textColor = NovixTheme.colors.body
-        )
+        if (!rate.isNullOrBlank()) {
+            IconWithText(
+                icon = drawable.star,
+                contentDesc = stringResource(star),
+                tint = NovixTheme.colors.yellowAccent,
+                text = rate,
+                textColor = NovixTheme.colors.title
+            )
+        }
+
+        if (!rate.isNullOrBlank() && !time.isNullOrBlank()) {
+            Dot()
+        }
+
+        if (!time.isNullOrBlank()) {
+            IconWithText(
+                icon = drawable.time_04,
+                contentDesc = stringResource(time_icon),
+                tint = NovixTheme.colors.body,
+                text = time,
+                textColor = NovixTheme.colors.body
+            )
+        }
+
+        if (
+            (!time.isNullOrBlank() && !date.isNullOrBlank()) ||
+            (rate.isNullOrBlank() && !time.isNullOrBlank() && !date.isNullOrBlank())
+        ) {
+            Dot()
+        }
+
+        if (!date.isNullOrBlank()) {
+            IconWithText(
+                icon = drawable.calendar_03,
+                contentDesc = stringResource(calendar),
+                tint = NovixTheme.colors.body,
+                text = date,
+                textColor = NovixTheme.colors.body
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -122,7 +122,6 @@ fun MovieDetailsContent(
             lazyState.firstVisibleItemIndex > 0 || lazyState.firstVisibleItemScrollOffset > 500
         }
     }
-    val iconTint = if (isScrolledFarEnough.value) NovixTheme.colors.title else Color.White
 
     Box(
         modifier = Modifier
@@ -153,7 +152,6 @@ fun MovieDetailsContent(
                     .size(40.dp)
                     .clip(RoundedCornerShape(16))
                     .align(Alignment.TopEnd),
-                tint = iconTint
             )
 
             ButtonIcon(
@@ -165,7 +163,6 @@ fun MovieDetailsContent(
                     .size(40.dp)
                     .clip(RoundedCornerShape(16))
                     .align(Alignment.TopStart),
-                tint = iconTint
             )
         }
 
@@ -260,65 +257,67 @@ fun MovieDetailsContent(
                 }
             }
 
-            item {
-                Text(
-                    text = stringResource(com.london.presentation.R.string.cast),
-                    style = NovixTheme.typography.title.medium,
-                    color = NovixTheme.colors.title,
-                    modifier = Modifier.padding(start = 16.dp, top = 16.dp)
-                )
-            }
+            if (state.genres.isNotEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(com.london.presentation.R.string.cast),
+                        style = NovixTheme.typography.title.medium,
+                        color = NovixTheme.colors.title,
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp)
+                    )
 
-            item {
-                LazyHorizontalGrid(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(100.dp),
-                    rows = GridCells.Fixed(1),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp),
-                    contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp)
-                ) {
-                    items(state.genres) { actor ->
-                        ActorItem(
-                            actorName = actor.name,
-                            characterName = actor.characterName,
-                            imageRes = actor.avatarUrl,
-                            modifier = Modifier.defaultMinSize(minWidth = 375.dp)
-                        )
+                    LazyHorizontalGrid(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp),
+                        rows = GridCells.Fixed(1),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(vertical = 8.dp, horizontal = 16.dp)
+                    ) {
+                        items(state.genres) { actor ->
+                            ActorItem(
+                                actorName = actor.name,
+                                characterName = actor.characterName,
+                                imageRes = actor.avatarUrl,
+                                modifier = Modifier.defaultMinSize(minWidth = 375.dp)
+                            )
+                        }
                     }
                 }
             }
 
-            item {
-                Text(
-                    text = stringResource(more_like_this),
-                    style = NovixTheme.typography.title.medium,
-                    color = NovixTheme.colors.title,
-                    modifier = Modifier.padding(start = 16.dp, top = 16.dp)
-                )
-            }
+            if (state.similarMovies.isNotEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(more_like_this),
+                        style = NovixTheme.typography.title.medium,
+                        color = NovixTheme.colors.title,
+                        modifier = Modifier.padding(start = 16.dp, top = 16.dp)
+                    )
+                }
 
-            items(state.similarMovies.chunked(2)) { rowItems ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp)
-                        .padding(top = 12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(12.dp)
-                ) {
-                    rowItems.forEach { movie ->
-                        HomeCard(
-                            imageUrl = movie.image,
-                            isSaved = movie.isSaved,
-                            onSaveClick = {
-                                // TODO
-                            },
-                            modifier = Modifier
-                                .weight(1f)
-                        )
-                    }
-                    if (rowItems.size == 1) {
-                        Spacer(modifier = Modifier.weight(1f)) // fill empty space if odd item count
+                items(state.similarMovies.chunked(2)) { rowItems ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp)
+                            .padding(top = 12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        rowItems.forEach { movie ->
+                            HomeCard(
+                                imageUrl = movie.image,
+                                isSaved = movie.isSaved,
+                                onSaveClick = {
+                                    // TODO
+                                },
+                                modifier = Modifier
+                                    .weight(1f)
+                            )
+                        }
+                        if (rowItems.size == 1) {
+                            Spacer(modifier = Modifier.weight(1f)) // fill empty space if odd item count
+                        }
                     }
                 }
             }

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsUiState.kt
@@ -9,7 +9,7 @@ data class MovieDetailsUiState(
     val movieDuration: String = "",
     val releaseDate: String = "",
     val movieOverview: String = "",
-    val genres: List<ActorUIState> = listOf(),
+    val actors: List<ActorUIState> = listOf(),
     val similarMovies: List<SimilarMovieUIState> = listOf(),
     val movieHaveTrailer: Boolean = false,
     val isRated: Boolean = false,

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/mapper.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/mapper.kt
@@ -18,7 +18,7 @@ fun mapToUiState(
         movieDuration = movieDetails.movieDuration,
         releaseDate = movieDetails.releaseDate,
         movieOverview = movieDetails.movieOverview,
-        genres = mapActorsToUiState(movieDetails.actors),
+        actors = mapActorsToUiState(movieDetails.actors),
         similarMovies = mapSimilarMoviesToUiState(movieDetails.similarMovies),
         movieHaveTrailer = movieDetails.movieHaveTrailer,
         isRated = currentUiState.isRated,


### PR DESCRIPTION
# What does this PR do?

- Changed the `tint` parameter in `ButtonIcon` and `SaveIcon` to use `NovixTheme.colors.title`.
- Removed the `iconTint` variable in `MovieDetailsScreen` as the tint is now consistent.
- `Cast` and `More Like This` sections in `MovieDetailsScreen` will now only be displayed if their respective data (genres and similar movies) is not empty.

- renames the `genres` property to `actors` in the `MovieDetailsUiState` data class and updates its usages in `MovieDetailsScreen.kt` and `mapper.kt`.

- The `RatingAndMetaRow` composable in `MovieDetailsScreen.kt` has been updated to conditionally render the movie's rating, duration, and release date.

- Each item (rating, time, date) will now only be displayed if its corresponding value is not null or blank.
- The separating dots between items will also be rendered conditionally, appearing only when there are adjacent visible items.
