### PR TITLE
Fix: Apply navigationBarsPadding to MovieDetailsScreen

### DIFF
--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -19,11 +19,10 @@ import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
@@ -167,8 +166,9 @@ fun MovieDetailsContent(
         }
 
         LazyColumn(
-            modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(bottom = 100.dp),
+            modifier = Modifier
+                .fillMaxSize()
+                .navigationBarsPadding(),
             state = lazyState
         ) {
             item {
@@ -327,8 +327,9 @@ fun MovieDetailsContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = if (state.movieHaveTrailer) 16.dp else 24.dp)
-                .align(Alignment.BottomCenter)
-                .windowInsetsPadding(WindowInsets.navigationBars),
+                .padding(bottom = 24.dp)
+                .navigationBarsPadding()
+                .align(Alignment.BottomCenter),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             if (!state.movieHaveTrailer) {


### PR DESCRIPTION
# What does this PR do?

This commit addresses an issue where content in the MovieDetailsScreen was being obscured by the navigation bar.

The following changes were made:
- Applied `navigationBarsPadding()` to the `LazyColumn` to ensure its content is padded correctly.
- Applied `navigationBarsPadding()` to the bottom button row and adjusted its bottom padding.
