### PR TITLE
Fix: correct nav bar horizontal padding

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
@@ -79,8 +79,7 @@ fun <T> NavBar(
         modifier = modifier
             .fillMaxWidth()
             .topBorder(navBarColors.topBorderColor, 1.dp)
-            .background(color = navBarColors.backgroundColor)
-            .padding(horizontal = 24.dp),
+            .background(color = navBarColors.backgroundColor),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically
     ) {


### PR DESCRIPTION
# What does this PR do?

This PR removes the duplicate padding explicitly provided, as it's already implemented implicitly by the horizontal arrangement of Space evenly.