### PR TITLE
Refactor: Pass language parameter in API calls for details screens

### DIFF
--- a/data/src/main/java/com/london/data/datasource/remote/details/actordetails/ActorDetailsRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/actordetails/ActorDetailsRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.london.data.datasource.remote.details.actordetails
 
+import com.london.data.datasource.device.DeviceConfigurationDataSource
 import com.london.data.datasource.remote.ApiConstants
 import com.london.data.datasource.remote.details.actordetails.model.ActorDetailsResponse
 import com.london.data.datasource.remote.details.actordetails.model.actorimage.ActorImageResponse
@@ -13,17 +14,30 @@ import org.koin.core.annotation.Single
 @Single
 class ActorDetailsRemoteDataSourceImpl(
     private val ktorClient: HttpClient,
+    private val deviceConfigurationDataSource: DeviceConfigurationDataSource
 ) : ActorDetailsRemoteDataSource {
 
     override suspend fun getActorDetailsById(actorId: Int): ActorDetailsResponse =
-        ktorClient.get(path = ApiConstants.getActorDetailsPath(actorId))
+        ktorClient.get(
+            path = ApiConstants.getActorDetailsPath(actorId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getActorMovieById(actorId: Int): ActorMovieDetailsResponse =
-        ktorClient.get(path = ApiConstants.getActorMoviesPath(actorId))
+        ktorClient.get(
+            path = ApiConstants.getActorMoviesPath(actorId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getActorTvShowById(actorId: Int): ActorTvShowDetailsResponse =
-        ktorClient.get(path = ApiConstants.getActorTvShowsPath(actorId))
+        ktorClient.get(
+            path = ApiConstants.getActorTvShowsPath(actorId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getActorImagePath(actorId: Int): ActorImageResponse =
-        ktorClient.get(path = ApiConstants.getActorImagePath(actorId))
+        ktorClient.get(
+            path = ApiConstants.getActorImagePath(actorId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 }

--- a/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/MovieDetailsRemoteImpl.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/MovieDetailsRemoteImpl.kt
@@ -1,5 +1,6 @@
 package com.london.data.datasource.remote.details.moviedetails
 
+import com.london.data.datasource.device.DeviceConfigurationDataSource
 import com.london.data.datasource.remote.ApiConstants
 import com.london.data.datasource.remote.details.moviedetails.model.moviecast.MovieCastResponse
 import com.london.data.datasource.remote.details.moviedetails.model.moviedetails.MovieDetailsResponse
@@ -12,16 +13,29 @@ import org.koin.core.annotation.Single
 @Single
 class MovieDetailsRemoteImpl(
     private val ktorClient: HttpClient,
+    private val deviceConfigurationDataSource: DeviceConfigurationDataSource
 ) : MovieDetailsRemote {
     override suspend fun getMovieDetails(movieId: Int): MovieDetailsResponse =
-        ktorClient.get(ApiConstants.getMovieDetailsPath(movieId))
+        ktorClient.get(
+            ApiConstants.getMovieDetailsPath(movieId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getSimilarMovies(movieId: Int): SimilarMoviesResponse =
-        ktorClient.get(ApiConstants.getSimilarMoviesPath(movieId))
+        ktorClient.get(
+            ApiConstants.getSimilarMoviesPath(movieId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getMovieCast(movieId: Int): MovieCastResponse =
-        ktorClient.get(ApiConstants.getMovieCastPath(movieId))
+        ktorClient.get(
+            ApiConstants.getMovieCastPath(movieId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getMovieImages(movieId: Int): MovieImagesResponse =
-        ktorClient.get(ApiConstants.getMovieImagesPath(movieId))
+        ktorClient.get(
+            ApiConstants.getMovieImagesPath(movieId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 }

--- a/data/src/main/java/com/london/data/datasource/remote/details/tvshowdetails/TvShowDetailsRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/tvshowdetails/TvShowDetailsRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.london.data.datasource.remote.details.tvshowdetails
 
+import com.london.data.datasource.device.DeviceConfigurationDataSource
 import com.london.data.datasource.remote.ApiConstants
 import com.london.data.datasource.remote.details.tvshowdetails.model.TvShowCastRemoteResponse
 import com.london.data.datasource.remote.details.tvshowdetails.model.TvShowDetailsRemoteResponse
@@ -13,22 +14,35 @@ import org.koin.core.annotation.Single
 @Single
 class TvShowDetailsRemoteDataSourceImpl(
     private val ktorClient: HttpClient,
+    private val deviceConfigurationDataSource: DeviceConfigurationDataSource
 ) : TvShowDetailsRemoteDataSource {
 
     override suspend fun getTvShowDetailsById(tvShowId: Int): TvShowDetailsRemoteResponse =
-        ktorClient.get(path = ApiConstants.getTvShowDetailsPath(tvShowId))
+        ktorClient.get(
+            path = ApiConstants.getTvShowDetailsPath(tvShowId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getTvShowEpisodesBySeason(
         tvShowId: Int,
         seasonNumber: Int
     ): TvShowEpisodesRemoteResponse =
-        ktorClient.get(path = ApiConstants.getTvShowEpisodeBySeasonPath(tvShowId, seasonNumber))
+        ktorClient.get(
+            path = ApiConstants.getTvShowEpisodeBySeasonPath(tvShowId, seasonNumber),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getCastsByTvShowId(tvShowId: Int): TvShowCastRemoteResponse =
-        ktorClient.get(path = ApiConstants.getCastTvShowPath(tvShowId))
+        ktorClient.get(
+            path = ApiConstants.getCastTvShowPath(tvShowId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getTvShowImagesById(tvShowId: Int): TvShowImagesRemoteResponse =
-        ktorClient.get(path = ApiConstants.getImagesTvShowPath(tvShowId))
+        ktorClient.get(
+            path = ApiConstants.getImagesTvShowPath(tvShowId),
+            params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
+        )
 
     override suspend fun getEpisodeDetailsByPosition(
         tvShowId: Int,
@@ -39,6 +53,7 @@ class TvShowDetailsRemoteDataSourceImpl(
             tvShowId,
             seasonNumber,
             episodeNumber
-        )
+        ),
+        params = mapOf("language" to deviceConfigurationDataSource.getCurrentLanguage())
     )
 }

--- a/data/src/main/java/com/london/data/di/DataModule.kt
+++ b/data/src/main/java/com/london/data/di/DataModule.kt
@@ -5,4 +5,4 @@ import org.koin.core.annotation.Module
 
 @Module(includes =[DataBaseModule::class, NetworkModule::class] )
 @ComponentScan("com.london.data.**")
-class DataModule{}
+class DataModule

--- a/data/src/test/java/com/london/data/datasource/remote/moviedetails/MovieDetailsResponseImplTest.kt
+++ b/data/src/test/java/com/london/data/datasource/remote/moviedetails/MovieDetailsResponseImplTest.kt
@@ -2,6 +2,7 @@ package com.london.data.datasource.remote.moviedetails
 
 import android.util.Log
 import com.google.common.truth.Truth.assertThat
+import com.london.data.datasource.device.DeviceConfigurationDataSource
 import com.london.data.datasource.remote.details.moviedetails.MovieDetailsRemoteImpl
 import com.london.data.datasource.remote.details.moviedetails.model.moviecast.MovieCastResponse
 import com.london.data.datasource.remote.details.moviedetails.model.moviecast.MovieImages
@@ -19,6 +20,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -30,6 +32,7 @@ class MovieDetailsResponseImplTest {
 
     private lateinit var httpClient: HttpClient
     private lateinit var remote: MovieDetailsRemoteImpl
+    private lateinit var deviceConfigurationDataSource: DeviceConfigurationDataSource
 
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -38,6 +41,7 @@ class MovieDetailsResponseImplTest {
         mockkStatic(Log::class)
         every { Log.d(any(), any()) } returns 0
         every { Log.e(any(), any(), any()) } returns 0
+        deviceConfigurationDataSource = mockk(relaxed = true)
     }
 
     private fun setUp(handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData) {
@@ -49,7 +53,7 @@ class MovieDetailsResponseImplTest {
                 json(json)
             }
         }
-        remote = MovieDetailsRemoteImpl(httpClient)
+        remote = MovieDetailsRemoteImpl(httpClient, deviceConfigurationDataSource)
     }
 
     @Test


### PR DESCRIPTION
# What does this PR do?

This PR updates the remote data sources for TV show details, movie details, and actor details to include the current device language as a parameter in API requests.

The `DeviceConfigurationDataSource` is now injected into:
- `TvShowDetailsRemoteDataSourceImpl`
- `MovieDetailsRemoteImpl`
- `ActorDetailsRemoteDataSourceImpl`

The `language` parameter is added to the respective API calls within these classes.

Additionally, the `DataModule` class declaration was simplified by removing the empty curly braces.

## Type of Change
- [x] ✨ New feature
- [x] 🎨 UI changes

## Changes Made
- [x] Data

## Checklist
- [x] Ready for review
