### PR TITLE
Fix: Address nullability and display issues in movie details

### DIFF
--- a/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviecast/Backdrop.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviecast/Backdrop.kt
@@ -9,7 +9,7 @@ data class Backdrop(
     val aspectRatio: Double?,
     val height: Int?,
     @SerialName("iso_639_1")
-    val iso6391: String??,
+    val iso6391: String?,
     @SerialName("file_path")
     val filePath: String?,
     @SerialName("vote_average")

--- a/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviedetails/MovieDetailsResponse.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviedetails/MovieDetailsResponse.kt
@@ -6,16 +6,16 @@ import kotlinx.serialization.Serializable
 data class MovieDetailsResponse(
     val adult: Boolean?,
     @SerialName("backdrop_path")
-    val backdropPath: String,
+    val backdropPath: String?,
     @SerialName("belongs_to_collection")
-    val belongsToCollection: CollectionDetails,
+    val belongsToCollection: CollectionDetails?,
     val budget: Int?,
     @SerialName("genres")
     val genreRemote: List<GenreRemote>?,
     val homepage: String?,
     val id: Int?,
     @SerialName("imdb_id")
-    val imdbId: String,
+    val imdbId: String?,
     @SerialName("origin_country")
     val originCountry: List<String>?,
     @SerialName("original_language")
@@ -25,13 +25,13 @@ data class MovieDetailsResponse(
     val overview: String?,
     val popularity: Double?,
     @SerialName("poster_path")
-    val posterPath: String,
+    val posterPath: String?,
     @SerialName("production_companies")
     val productionCompanies: List<ProductionCompany>?,
     @SerialName("production_countries")
     val productionCountries: List<ProductionCountry>?,
     @SerialName("release_date")
-    val releaseDate: String,
+    val releaseDate: String?,
     val revenue: Long?,
     val runtime: Int?,
     @SerialName("spoken_languages")

--- a/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviedetails/MovieDetailsResponse.kt
+++ b/data/src/main/java/com/london/data/datasource/remote/details/moviedetails/model/moviedetails/MovieDetailsResponse.kt
@@ -6,16 +6,16 @@ import kotlinx.serialization.Serializable
 data class MovieDetailsResponse(
     val adult: Boolean?,
     @SerialName("backdrop_path")
-    val backdropPath: String??,
+    val backdropPath: String,
     @SerialName("belongs_to_collection")
-    val belongsToCollection: CollectionDetails??,
+    val belongsToCollection: CollectionDetails,
     val budget: Int?,
     @SerialName("genres")
     val genreRemote: List<GenreRemote>?,
     val homepage: String?,
     val id: Int?,
     @SerialName("imdb_id")
-    val imdbId: String??,
+    val imdbId: String,
     @SerialName("origin_country")
     val originCountry: List<String>?,
     @SerialName("original_language")
@@ -25,13 +25,13 @@ data class MovieDetailsResponse(
     val overview: String?,
     val popularity: Double?,
     @SerialName("poster_path")
-    val posterPath: String??,
+    val posterPath: String,
     @SerialName("production_companies")
     val productionCompanies: List<ProductionCompany>?,
     @SerialName("production_countries")
     val productionCountries: List<ProductionCountry>?,
     @SerialName("release_date")
-    val releaseDate: String??,
+    val releaseDate: String,
     val revenue: Long?,
     val runtime: Int?,
     @SerialName("spoken_languages")

--- a/data/src/main/java/com/london/data/repository/MovieDetailsRepoImpl.kt
+++ b/data/src/main/java/com/london/data/repository/MovieDetailsRepoImpl.kt
@@ -26,7 +26,8 @@ class MovieDetailsRepoImpl(
                 val movieDetailsRemote = movieDetailsRemote.getMovieDetails(id)
                 movieDetailsRemote.toEntity(
                     genres = movieDetailsRemote.genreRemote?.map { it.toGenre() } ?: emptyList(),
-                    movieImages = getMovieImagesById(id)
+                    movieImages = getMovieImagesById(id),
+                    movieDuration = movieDetailsRemote.runtime.toString(),
                 )
             },
             error = { cause -> GetMovieDetailsException(cause) }

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -218,7 +218,7 @@ fun MovieDetailsContent(
                                 color = NovixTheme.colors.title,
                                 modifier = Modifier.defaultMinSize(minHeight = 56.dp)
                             )
-                            GenreRow(state.movieGenres,onGenreClick)
+                            GenreRow(state.movieGenres, onGenreClick)
                             RatingAndMetaRow(
                                 rate = state.movieRating,
                                 time = state.movieDuration,
@@ -360,11 +360,12 @@ private fun RatingAndMetaRow(
         }
 
         if (!time.isNullOrBlank()) {
+            val timeInt = time.toInt()
             IconWithText(
                 icon = drawable.time_04,
                 contentDesc = stringResource(time_icon),
                 tint = NovixTheme.colors.body,
-                text = time,
+                text = "${timeInt / 60}h ${timeInt % 60}m",
                 textColor = NovixTheme.colors.body
             )
         }
@@ -498,7 +499,7 @@ private fun MovieDetailsPreview() {
 
         ),
         movieName = "The Shawshank Redemption",
-        movieGenres = listOf( Genre(1,"")),
+        movieGenres = listOf(Genre(1, "")),
         movieRating = "9.9",
         movieDuration = "2h 22m",
         releaseDate = "1994-09-22",
@@ -526,6 +527,6 @@ private fun MovieDetailsPreview() {
     )
 
     NovixTheme {
-        MovieDetailsContent(state = fakeState, {}, {}, {},{})
+        MovieDetailsContent(state = fakeState, {}, {}, {}, {})
     }
 }


### PR DESCRIPTION
# What does this PR do?

This PR resolves several issues related to nullability in movie data models and improves the display of movie duration.

- **Data Models:** Updated `Backdrop` and `MovieDetailsResponse` to correctly handle nullable fields, preventing potential crashes.
- **MovieDetailsScreen:**
    - Corrected the display of movie duration to show hours and minutes (e.g., "2h 22m") instead of just minutes.
    - Minor formatting adjustments in `GenreRow` and `MovieDetailsContent` preview.
- **MovieDetailsRepoImpl:** Ensured `movieDuration` is correctly passed when converting remote movie details to the local entity.

<img width="555" height="501" alt="image" src="https://github.com/user-attachments/assets/539e5523-af30-40dc-bafa-461f4710dbb1" />

