### PR TITLE
Refactor: Show error image when no movie images are available

### DIFF
--- a/presentation/src/main/java/com/london/presentation/screen/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/actor/ActorDetailsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -106,7 +107,7 @@ fun ActorScreenContent(
                 Box {
                     uiState.actorImageDetails?.let {
                         CustomBackDropImage(
-                            images = it,
+                            images = it, modifier.padding(bottom = 16.dp)
                         )
                     }
                 }
@@ -144,6 +145,7 @@ fun ActorScreenContent(
                         modifier = Modifier.padding(start = 16.dp)
                     )
                     var isExpanded by remember { mutableStateOf(false) }
+
                     ConditionalText(
                         text = uiState.actorBiography,
                         expandedState = isExpanded,
@@ -169,7 +171,6 @@ fun ActorScreenContent(
                     ActorGallery(images = uiState.actorImageDetails)
                 }
             }
-
 
             item {
                 uiState.actorMovieDetails?.cast?.takeIf { it.isNotEmpty() }?.let { movieCast ->
@@ -202,7 +203,8 @@ fun ActorScreenContent(
                     )
                     TopTvShowsPicksList(
                         tvShow = tvShows,
-                        onNavigateToTvShowPicks = onNavigateToTvShowScreen)
+                        onNavigateToTvShowPicks = onNavigateToTvShowScreen
+                    )
                 }
             }
 
@@ -312,7 +314,8 @@ private fun CustomBackDropImage(
                 shape = RoundedCornerShape(
                     bottomStart = 12.dp, bottomEnd = 12.dp
                 )
-            )
+            ),
+        contentAlignment = Alignment.Center
     ) {
         if (images.isNotEmpty()) {
             val pagerState = rememberPagerState(
@@ -343,6 +346,8 @@ private fun CustomBackDropImage(
                     errorContent = { ErrorImage() },
                     loadingContent = { CircularLoading(modifier = Modifier) })
             }
+        } else {
+            ErrorImage()
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/screen/details/actor/ActorDetailsUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/actor/ActorDetailsUiState.kt
@@ -21,4 +21,5 @@ data class ActorDetailsUiState(
     val tvShowError: Boolean = false,
     val tvShowId: Int = 1,
     val movieId: Int = 1,
+    val expanded: Boolean = false
 )

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -53,6 +53,7 @@ import com.london.designsystem.component.CircularLoading
 import com.london.designsystem.component.HomeCard
 import com.london.designsystem.component.ImageView
 import com.london.designsystem.component.NovixCarousalRow
+import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.noRippleClickable
 import com.london.domain.entity.moviedatails.Genre
@@ -456,28 +457,32 @@ private fun MovieDetailsImage(
             .clip(RoundedCornerShape(12.dp)),
         contentAlignment = Alignment.Center
     ) {
-        images.forEachIndexed { index, image ->
-            AnimatedVisibility(
-                visible = currentImageIndex == index,
-                enter = slideInHorizontally(
-                    initialOffsetX = { if (direction > 0) it else -it },
-                    animationSpec = tween(durationMillis = 1000)
-                ),
-                exit = slideOutHorizontally(
-                    targetOffsetX = { if (direction > 0) -it else it },
-                    animationSpec = tween(durationMillis = 1000)
-                ),
-            ) {
-                ImageView(
-                    model = image,
-                    contentDescription = imageDescription,
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .clip(RoundedCornerShape(12.dp)),
-                    onLoadingStateChange = { loadingState.value = it },
-                )
+        if (images.isNotEmpty()) {
+            images.forEachIndexed { index, image ->
+                AnimatedVisibility(
+                    visible = currentImageIndex == index,
+                    enter = slideInHorizontally(
+                        initialOffsetX = { if (direction > 0) it else -it },
+                        animationSpec = tween(durationMillis = 1000)
+                    ),
+                    exit = slideOutHorizontally(
+                        targetOffsetX = { if (direction > 0) -it else it },
+                        animationSpec = tween(durationMillis = 1000)
+                    ),
+                ) {
+                    ImageView(
+                        model = image,
+                        contentDescription = imageDescription,
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clip(RoundedCornerShape(12.dp)),
+                        onLoadingStateChange = { loadingState.value = it },
+                    )
+                }
             }
+        } else {
+            ErrorImage()
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/movieDetalis/MovieDetailsScreen.kt
@@ -54,8 +54,6 @@ import com.london.designsystem.component.HomeCard
 import com.london.designsystem.component.ImageView
 import com.london.designsystem.component.NovixCarousalRow
 import com.london.designsystem.component.button.ErrorImage
-import com.london.designsystem.component.SaveIcon
-import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.noRippleClickable
 import com.london.domain.entity.moviedatails.Genre


### PR DESCRIPTION
# What does this PR do?
This PR updates the `ImagesContent` composable to display an `ErrorImage` when the `images` list is empty. Previously, it would attempt to iterate over an empty list, leading to no images being displayed. Now, it provides a clear visual indication when no images are present.
## Checklist
- [ ] Code builds without warnings
- [ ] Self-reviewed
- [ ] Tests pass
- [ ] Ready for review
