### PR TITLE
fix: handle empty image list in tv show details pager

### DIFF
--- a/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -150,11 +150,9 @@ fun TvShowsDetailScreenContent(
         ) {
             item {
                 val images = uiState.tvImages
-                if (!images.isNullOrEmpty()) {
-                    CustomBackDropImagePager(
-                        images = images
-                    )
-                }
+                CustomBackDropImagePager(
+                    images = images ?: emptyList()
+                )
             }
 
             item {
@@ -233,71 +231,81 @@ fun CustomBackDropImagePager(
     modifier: Modifier = Modifier,
     images: List<ImageItemEntity>
 ) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(252.dp)
-            .clip(
-                shape = RoundedCornerShape(
-                    bottomStart = 12.dp,
-                    bottomEnd = 12.dp
-                )
+    if (images.isEmpty()) {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(252.dp)
+                .background(NovixTheme.colors.surface)
+        ) {
+            NovixCarousalRow(
+                dotsStates = listOf(false),
+                modifier = Modifier
+                    .padding(bottom = 48.dp)
+                    .height(16.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color = NovixTheme.colors.iconBackgroundLow, shape = RoundedCornerShape(8.dp))
+                    .border(width = 1.dp, color = NovixTheme.colors.stroke, shape = RoundedCornerShape(8.dp))
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                    .align(Alignment.BottomCenter)
             )
-    ) {
-        val pagerState = rememberPagerState(
-            initialPage = 0,
-            pageCount = { images.size }
-        )
+        }
+    } else {
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .height(252.dp)
+                .clip(
+                    shape = RoundedCornerShape(
+                        bottomStart = 12.dp,
+                        bottomEnd = 12.dp
+                    )
+                )
+        ) {
+            val pagerState = rememberPagerState(
+                initialPage = 0,
+                pageCount = { images.size }
+            )
 
-        LaunchedEffect(Unit) {
-            if (images.size > 1) {
-                while (true) {
-                    delay(4000)
-                    val nextPage = (pagerState.currentPage + 1) % images.size
-                    pagerState.animateScrollToPage(nextPage)
+            LaunchedEffect(Unit) {
+                if (images.size > 1) {
+                    while (true) {
+                        delay(4000)
+                        val nextPage = (pagerState.currentPage + 1) % images.size
+                        pagerState.animateScrollToPage(nextPage)
+                    }
                 }
             }
-        }
 
-        HorizontalPager(
-            modifier = Modifier.align(Alignment.Center),
-            state = pagerState,
-        ) { pageIndex ->
-            ImageViewFilter(
+            HorizontalPager(
+                modifier = Modifier.align(Alignment.Center),
+                state = pagerState,
+            ) { pageIndex ->
+                ImageViewFilter(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(252.dp),
+                    contentScale = ContentScale.FillBounds,
+                    model = images[pageIndex].fileUrl,
+                    contentDescription = "TV Show Image ${pageIndex + 1}",
+                    errorContent = { ErrorImage() },
+                    loadingContent = { CircularLoading(modifier = Modifier) },
+                    moderatedContent = { UnSuitableEye() }
+                )
+            }
+
+            NovixCarousalRow(
+                dotsStates = List(images.size) { index -> index == pagerState.currentPage },
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(252.dp),
-                contentScale = ContentScale.FillBounds,
-                model = images[pageIndex].fileUrl,
-                contentDescription = "TV Show Image ${pageIndex + 1}",
-                errorContent = { ErrorImage() },
-                loadingContent = { CircularLoading(modifier = Modifier) },
-                moderatedContent = { UnSuitableEye() }
+                    .padding(bottom = 48.dp)
+                    .height(16.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(color = NovixTheme.colors.iconBackgroundLow, shape = RoundedCornerShape(8.dp))
+                    .border(width = 1.dp, color = NovixTheme.colors.stroke, shape = RoundedCornerShape(8.dp))
+                    .padding(horizontal = 12.dp, vertical = 4.dp)
+                    .align(Alignment.BottomCenter)
             )
         }
-
-        val dotsStates = List(images.size) { index ->
-            index == pagerState.currentPage
-        }
-
-        NovixCarousalRow(
-            dotsStates = dotsStates,
-            modifier = Modifier
-                .padding(bottom = 48.dp)
-                .height(16.dp)
-                .clip(RoundedCornerShape(8.dp))
-                .background(
-                    color = NovixTheme.colors.iconBackgroundLow,
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .border(
-                    width = 1.dp,
-                    color = NovixTheme.colors.stroke,
-                    shape = RoundedCornerShape(8.dp)
-                )
-                .padding(horizontal = 12.dp, vertical = 4.dp)
-                .align(Alignment.BottomCenter)
-        )
     }
 }
 


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Screenshots
<img width="352" height="768" alt="image" src="https://github.com/user-attachments/assets/61ad1cf0-3e47-4709-bd70-11811c37b741" />

