### PR TITLE
feat: timber configuration for debugging

### DIFF
--- a/app/src/main/java/com/london/app/di/NovixApplication.kt
+++ b/app/src/main/java/com/london/app/di/NovixApplication.kt
@@ -1,19 +1,46 @@
 package com.london.app.di
 
 import android.app.Application
+import com.london.data.BuildConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import org.koin.ksp.generated.module
+import timber.log.Timber
 
 class NovixApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        timberConfig()
         startKoin {
             androidLogger(level =Level.DEBUG)
             androidContext(this@NovixApplication)
             modules(AppModule().module)
         }
+    }
+
+    private fun timberConfig() {
+        if (BuildConfig.DEBUG)
+            Timber.plant(object : Timber.DebugTree() {
+                /**
+                 * Override [log] to modify the tag and add a "global tag" prefix to it. You can rename the String "global_tag_" as you see fit.
+                 */
+                override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                    super.log(priority, "DEBUGGING", "$tag -> $message", t)
+                }
+
+                /**
+                 * Override [createStackElementTag] to include a add a "method name" to the tag.
+                 */
+                override fun createStackElementTag(element: StackTraceElement): String {
+                    return String.format(
+                        "%s:%s$%s()",
+                        element.fileName,
+                        element.lineNumber,
+                        element.methodName,
+                    )
+                }
+            })
     }
 }


### PR DESCRIPTION
# What does this PR do?

This PR introduces Timber configuration for enhanced debugging in the NovixApplication.

- Timber is initialized in the `onCreate` method.
- In debug builds, a custom `DebugTree` is planted.
- The custom `DebugTree` overrides `log` to prepend "DEBUGGING" to the tag and includes the original tag in the message.
- It also overrides `createStackElementTag` to format the tag with filename, line number, and method name for more precise logging.
