### PR TITLE
feat: implement PopularSection and handle navigation

### DIFF
--- a/app/src/main/java/com/london/app/navigation/NovixApp.kt
+++ b/app/src/main/java/com/london/app/navigation/NovixApp.kt
@@ -101,7 +101,11 @@ fun NovixApp() {
                 enterTransition = { fadeIn(tween(500)) },
                 popExitTransition = { fadeOut(tween(500)) },
             ) {
-                HomeScreen()
+                HomeScreen(
+                    onMovieClick = { movieId ->
+                        navController.navigate(MovieDetails(movieId))
+                    }
+                )
             }
 
             composable<Search>(

--- a/domain/src/main/java/com/london/domain/entity/recent/RecentSearch.kt
+++ b/domain/src/main/java/com/london/domain/entity/recent/RecentSearch.kt
@@ -1,5 +1,8 @@
 package com.london.domain.entity.recent
 
+import com.london.domain.KoverIgnore
+
+@KoverIgnore
 data class RecentSearch(
     val id: Int,
     val query: String,

--- a/domain/src/main/java/com/london/domain/entity/review/ReviewEntity.kt
+++ b/domain/src/main/java/com/london/domain/entity/review/ReviewEntity.kt
@@ -1,5 +1,8 @@
 package com.london.domain.entity.review
 
+import com.london.domain.KoverIgnore
+
+@KoverIgnore
 data class ReviewEntity(
     val authorName: String,
     val authorDetails: AuthorDetails,
@@ -10,6 +13,7 @@ data class ReviewEntity(
     val url: String
 )
 
+@KoverIgnore
 data class AuthorDetails(
     val name: String,
     val username: String,

--- a/domain/src/main/java/com/london/domain/usecase/GetPopularMovies.kt
+++ b/domain/src/main/java/com/london/domain/usecase/GetPopularMovies.kt
@@ -9,5 +9,9 @@ class GetPopularMovies(
     @Provided
     private val popularRepository: PopularRepository
 ) {
-    suspend fun invoke() = popularRepository.getPopularMovies()
+    suspend fun invoke(limit: Int = LIMIT) = popularRepository.getPopularMovies().take(limit)
+
+    companion object{
+        const val LIMIT = 5
+    }
 }

--- a/presentation/src/main/java/com/london/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/home/HomeScreen.kt
@@ -4,14 +4,20 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
@@ -24,19 +30,27 @@ import com.london.designsystem.component.HomeCard
 import com.london.designsystem.component.NovixChip
 import com.london.designsystem.component.Text
 import com.london.designsystem.theme.NovixTheme
-import com.london.designsystem.theme.ThemePreviews
 import com.london.presentation.R
 import com.london.presentation.screen.LoadingScreen
 import com.london.presentation.screen.NetworkErrorScreen
 import com.london.presentation.screen.base.ErrorState
+import com.london.presentation.utils.Listen
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun HomeScreen(
+    onMovieClick: (movieId: Int) -> Unit = {},
     viewModel: HomeViewModel = koinViewModel()
 ) {
 
     val uiState by viewModel.state.collectAsStateWithLifecycle()
+    val effect by viewModel.effect.collectAsState(null)
+
+    effect?.Listen { currentEffect ->
+        when (currentEffect) {
+            is HomeScreenEffect.NavigationPopularCard -> onMovieClick(currentEffect.id)
+        }
+    }
 
     when {
         uiState.isLoading -> LoadingScreen()
@@ -44,9 +58,10 @@ fun HomeScreen(
         else -> Content(
             onMovieClick = { },
             onGenreClick = { },
+            homeScreenContract = viewModel,
+            uiState = uiState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(top = 100.dp)
         )
     }
 }
@@ -55,6 +70,8 @@ fun HomeScreen(
 private fun Content(
     onMovieClick: (movieId: Int) -> Unit,
     onGenreClick: (genreId: Int) -> Unit,
+    homeScreenContract: HomeScreenContract,
+    uiState: HomeScreenUiState,
     modifier: Modifier = Modifier,
 ) {
     val density = LocalDensity.current
@@ -74,28 +91,66 @@ private fun Content(
         modifier = modifier
             .background(color = NovixTheme.colors.surface)
     ) {
+
         item(span = { GridItemSpan(maxLineSpan) }) {
-            Text(
-                text = stringResource(R.string.upcoming),
-                style = NovixTheme.typography.headline.small,
-                color = NovixTheme.colors.title
+            val pagerState =
+                rememberPagerState(initialPage = 0, pageCount = { uiState.popularMovies.size })
+            PopularSection(
+                modifier = modifier
+                    .requiredWidth(screenWidth),
+                pagerState = pagerState,
+                images = uiState.popularMovies.map { it.posterPath },
+                onSaveClick = {/* TODO */},
+                onCardClick = {
+                    homeScreenContract.onPopularCardClicked(
+                        uiState.popularMovies[pagerState.currentPage].id
+                    )
+                }
             )
         }
-        item(span = { GridItemSpan(maxLineSpan) }) {
-            GenresSection(
-                onGenreClick = onGenreClick,
-                screenWidth = screenWidth
-            )
-        }
-        items(10) {
-            HomeCard(
-                imageUrl = "",//TODO()
-                isSaved = false,
-                onSaveClick = { },//TODO()
-                modifier = Modifier.clickable { onMovieClick(it) })
-        }
+
+        upComingSection(
+            onMovieClick = onMovieClick,
+            onGenreClick = onGenreClick,
+            screenWidth = screenWidth,
+        )
     }
 }
+
+fun LazyGridScope.upComingSection(
+    onMovieClick: (movieId: Int) -> Unit,
+    onGenreClick: (genreId: Int) -> Unit,
+    screenWidth: Dp,
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        Text(
+            text = stringResource(R.string.upcoming),
+            style = NovixTheme.typography.headline.small,
+            color = NovixTheme.colors.title
+        )
+    }
+
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        Spacer(modifier = Modifier.height(8.dp))
+        GenresSection(
+            onGenreClick = onGenreClick,
+            screenWidth = screenWidth
+        )
+    }
+
+    items(10) {
+        HomeCard(
+            imageUrl = "", // TODO
+            isSaved = false,
+            onSaveClick = { }, // TODO
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+                .clickable { onMovieClick(it) }
+        )
+    }
+}
+
 
 @Composable
 private fun GenresSection(
@@ -115,13 +170,4 @@ private fun GenresSection(
             )
         }
     }
-}
-
-@ThemePreviews
-@Composable
-private fun Preview() {
-    Content(
-        onMovieClick = { },
-        onGenreClick = { },
-    )
 }

--- a/presentation/src/main/java/com/london/presentation/screen/home/HomeScreenContract.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/home/HomeScreenContract.kt
@@ -1,4 +1,5 @@
 package com.london.presentation.screen.home
 
 interface HomeScreenContract {
+    fun onPopularCardClicked(id: Int)
 }

--- a/presentation/src/main/java/com/london/presentation/screen/home/HomeScreenEffect.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/home/HomeScreenEffect.kt
@@ -1,4 +1,5 @@
 package com.london.presentation.screen.home
 
 interface HomeScreenEffect {
+    data class NavigationPopularCard(val id: Int): HomeScreenEffect
 }

--- a/presentation/src/main/java/com/london/presentation/screen/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/home/HomeViewModel.kt
@@ -7,7 +7,7 @@ import org.koin.android.annotation.KoinViewModel
 @KoinViewModel
 class HomeViewModel(
     private val getPopularMovies: GetPopularMovies
-) : BaseViewModel<HomeScreenUiState, HomeScreenEffect>(HomeScreenUiState()) {
+) : BaseViewModel<HomeScreenUiState, HomeScreenEffect>(HomeScreenUiState()), HomeScreenContract {
 
     init {
         initializePopularMovies()
@@ -26,5 +26,7 @@ class HomeViewModel(
         )
     }
 
-
+    override fun onPopularCardClicked(id: Int) {
+        emitEffect(HomeScreenEffect.NavigationPopularCard(id))
+    }
 }

--- a/presentation/src/main/java/com/london/presentation/screen/home/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/screen/home/PopularSection.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -57,13 +58,13 @@ fun PopularSection(
     val horizontalPadding = (screenWidth - cardWidth) / 2
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier.wrapContentHeight(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)
     ) {
         HorizontalPager(
             state = pagerState,
-            modifier = modifier,
+            modifier = modifier.wrapContentHeight(),
             pageSpacing = PAGE_SPACING_DP.dp,
             contentPadding = PaddingValues(horizontal = horizontalPadding)
         ) { page ->


### PR DESCRIPTION
# What does this PR do?

This PR implements the PopularSection in the HomeScreen, allowing users to view and navigate to popular movie details.

Key changes:
- Added `PopularSection` composable to display a horizontal pager of popular movies.
- Updated `HomeViewModel` to handle `onPopularCardClicked` events and emit a `NavigationPopularCard` effect.
- Modified `HomeScreen` to listen for navigation effects and navigate to the `MovieDetails` screen.
- Updated `GetPopularMovies` use case to accept a limit parameter for the number of movies to fetch, defaulting to 5.
- Adjusted layout and padding in `PopularSection` and `HomeScreen`.

## Type of Change
- [x] ✨ New feature
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI
- [x] Domain


## Screenshots
<img width="421" height="811" alt="image" src="https://github.com/user-attachments/assets/9a09e541-7780-4986-aa32-2db0f66357c2" />

## Checklist
- [x] Ready for review
