### PR TITLE
refactor: Replace `height` with `heightIn` for buttons

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/button/OutlineButton.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/button/OutlineButton.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -44,7 +44,7 @@ fun OutlineButton(
         ),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
         modifier = modifier
-            .height(48.dp)
+            .heightIn(48.dp)
             .defaultMinSize(minWidth = 78.dp)
     ) {
         if (hasLabel && text != null) {

--- a/designSystem/src/main/java/com/london/designsystem/component/button/PrimaryButton.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/button/PrimaryButton.kt
@@ -6,7 +6,7 @@ import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -45,7 +45,7 @@ fun PrimaryButton(
         onClick = onClick,
         enabled = enabled,
         modifier = modifier
-            .height(48.dp)
+            .heightIn(48.dp)
             .defaultMinSize(minWidth = 52.dp)
             .insetShadow(),
         shape = RoundedCornerShape(12.dp),


### PR DESCRIPTION
# What does this PR do?

This PR replaces the `height` modifier with `heightIn` for `PrimaryButton` and `OutlineButton` components.

Using `heightIn` allows the buttons to have a minimum height of 48.dp while still allowing them to grow taller if their content requires more space. This provides more flexibility in button sizing.

## Type of Change
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI


## Checklist
- [x] Ready for review
