### PR TITLE
feat: Add RTL support to PopularSection

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/color/DarkThemeColors.kt
+++ b/designSystem/src/main/java/com/london/designsystem/color/DarkThemeColors.kt
@@ -26,7 +26,7 @@ val DarkCocoaDark = Color(0xFF4D1D12)
 val DeepCrimsonDark = Color(0xFF39010C)
 val TealBlueDark = Color(0xFF3B99AC)
 val OceanDarkDark = Color(0xFF094E5C)
-val BlackLinearGradientDark = Color(0xff000000).copy(alpha = 0.5f)
+val BlackLinearGradientDark = Color(0xff000000).copy(alpha = 0.6f)
 val WhiteLinearGradientDark = Color(0xff000000).copy(alpha = 0f)
 
 val DarkNovixColors = NovixColors(

--- a/designSystem/src/main/java/com/london/designsystem/color/LightThemeColors.kt
+++ b/designSystem/src/main/java/com/london/designsystem/color/LightThemeColors.kt
@@ -26,7 +26,7 @@ val DarkCocoaLight = Color(0xFFBF4C33)
 val DeepCrimsonLight = Color(0xFF5B0113)
 val TealBlueLight = Color(0xFF3B99AC)
 val OceanDarkLight = Color(0xFF21606D)
-val BlackLinearGradientLight = Color(0xff000000).copy(alpha = 0.5f)
+val BlackLinearGradientLight = Color(0xff000000).copy(alpha = 0.6f)
 val WhiteLinearGradientLight = Color(0xff000000).copy(alpha = 0f)
 
 val LightNovixColors = NovixColors(

--- a/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
@@ -86,7 +86,7 @@ fun PopularSection(
             color = NovixTheme.colors.title,
             modifier = Modifier
                 .padding(start = 16.dp, end = 16.dp)
-                .align(if (isRtl) Alignment.End else Alignment.Start)
+                .align(Alignment.Start)
         )
 
         LaunchedEffect(Unit) {

--- a/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.london.designsystem.component.HomeCard
@@ -31,7 +33,6 @@ import com.london.designsystem.component.Text
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
 import com.london.presentation.shared.RatingItem
-import com.london.presentation.utils.toLocalizedNumbers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -65,6 +66,9 @@ fun PopularSection(
     onCardClick: () -> Unit,
 ) {
     val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    val isRtl = layoutDirection == LayoutDirection.Rtl
+
     val screenWidth = with(density) {
         LocalConfiguration.current.screenWidthDp.dp
     }
@@ -72,7 +76,7 @@ fun PopularSection(
     val horizontalPadding = (screenWidth - cardWidth) / 2
 
     Column(
-        modifier = modifier.heightIn(min=302.dp),
+        modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
 
@@ -82,14 +86,18 @@ fun PopularSection(
             color = NovixTheme.colors.title,
             modifier = Modifier
                 .padding(start = 16.dp, end = 16.dp)
-                .align(Alignment.Start)
+                .align(if (isRtl) Alignment.End else Alignment.Start)
         )
 
         LaunchedEffect(Unit) {
             if (images.size > 1) {
                 while (currentCoroutineContext().isActive) {
                     delay(4000)
-                    val nextPage = (pagerState.currentPage + 1) % images.size
+                    val nextPage = if (isRtl) {
+                        if (pagerState.currentPage == 0) images.size - 1 else pagerState.currentPage - 1
+                    } else {
+                        (pagerState.currentPage + 1) % images.size
+                    }
                     pagerState.animateScrollToPage(nextPage)
                 }
             }
@@ -100,19 +108,27 @@ fun PopularSection(
             modifier = Modifier
                 .heightIn(CARD_WIDTH_DP.dp),
             pageSpacing = PAGE_SPACING_DP.dp,
-            contentPadding = PaddingValues(horizontal = horizontalPadding)
+            contentPadding = PaddingValues(horizontal = horizontalPadding),
+            reverseLayout = isRtl
         ) { page ->
-            val pageOffset = (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+            val pageOffset = if (isRtl) {
+                (page - pagerState.currentPage) - pagerState.currentPageOffsetFraction
+            } else {
+                (pagerState.currentPage - page) + pagerState.currentPageOffsetFraction
+            }
 
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .wrapContentSize(Alignment.Center)
-                    .padding(horizontal =  CARD_HORIZONTAL_PADDING_DP.dp, vertical = CARD_HORIZONTAL_PADDING_DP.dp)
+                    .padding(horizontal = CARD_HORIZONTAL_PADDING_DP.dp, vertical = CARD_HORIZONTAL_PADDING_DP.dp)
                     .graphicsLayer {
+                        val rotationStart = if (isRtl) ROTATION_NEXT_DEGREES else ROTATION_PREVIOUS_DEGREES
+                        val rotationStop = if (isRtl) ROTATION_PREVIOUS_DEGREES else ROTATION_NEXT_DEGREES
+
                         rotationZ = lerp(
-                            start = ROTATION_PREVIOUS_DEGREES,
-                            stop = ROTATION_NEXT_DEGREES,
+                            start = rotationStart,
+                            stop = rotationStop,
                             fraction = (pageOffset + ROTATION_OFFSET_ADJUSTMENT) * ROTATION_FRACTION_MULTIPLIER
                         )
 
@@ -142,8 +158,8 @@ fun PopularSection(
                     Column(
                         modifier = Modifier
                             .padding(start = 8.dp, bottom = 6.dp, end = 8.dp)
-                            .align(Alignment.BottomStart),
-                        horizontalAlignment = Alignment.Start,
+                            .align(if (isRtl) Alignment.BottomEnd else Alignment.BottomStart),
+                        horizontalAlignment = if (isRtl) Alignment.End else Alignment.Start,
                     ) {
                         Text(
                             text = cardTitle,
@@ -156,10 +172,10 @@ fun PopularSection(
                         Row(
                             modifier = Modifier,
                             verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start
+                            horizontalArrangement = if (isRtl) Arrangement.End else Arrangement.Start
                         ) {
                             RatingItem(
-                                rating = cardRating.toLocalizedNumbers(),
+                                rating = cardRating,
                                 color = NovixTheme.colors.onPrimary
                             )
                         }


### PR DESCRIPTION
# What does this PR do?

This PR adds Right-to-Left (RTL) layout support to the `PopularSection` composable.

The following changes were made:
- Introduced `layoutDirection` and `isRtl` variables to determine the current layout direction.
- Adjusted alignment of the section title based on `isRtl`.
- Modified auto-scrolling logic to handle RTL pagination correctly.
- Updated `HorizontalPager` `reverseLayout` property based on `isRtl`.
- Adjusted page offset calculation for RTL layouts.
- Modified card rotation animation to work correctly with RTL.
- Aligned card content (title and rating) based on `isRtl`.
- Removed `toLocalizedNumbers()` call as it's no longer necessary.
- Removed explicit height constraint on the main column to allow for more flexible sizing.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
