### PR TITLE
fix: enhance ripple effects home card actor item category item

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/ActorItem.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/ActorItem.kt
@@ -1,6 +1,7 @@
 package com.london.designsystem.component
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,23 +37,28 @@ fun ActorItem(
     actorName: String,
     characterName: String?,
     imageRes: Any,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
         verticalAlignment = Alignment.Bottom,
     ) {
-        ActorImage(imageRes = imageRes)
+        ActorImage(imageRes = imageRes, onClick = onClick)
         TextSection(
             actorName = actorName,
             characterName = characterName,
+            onClick= onClick,
             modifier = Modifier.weight(1f)
         )
     }
 }
 
 @Composable
-private fun ActorImage(imageRes: Any) {
+private fun ActorImage(
+    imageRes: Any,
+    onClick: () -> Unit
+) {
     val imageShape = RoundedCornerShape(
         topStart = 12.dp,
         topEnd = 12.dp,
@@ -67,6 +73,7 @@ private fun ActorImage(imageRes: Any) {
             modifier = Modifier
                 .size(78.dp)
                 .clip(shape = imageShape)
+                .clickable(onClick = onClick)
                 .border(
                     width = 1.dp,
                     shape = imageShape,
@@ -125,6 +132,7 @@ fun Modifier.customBorder(
 private fun TextSection(
     actorName: String,
     characterName: String?,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val color = NovixTheme.colors.stroke
@@ -132,8 +140,10 @@ private fun TextSection(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .height( 55.dp)
+            .height(55.dp)
             .customBorder(color = color, isRtl = isRtl)
+            .clip(RoundedCornerShape(topEnd = 12.dp, bottomEnd = 12.dp))
+            .clickable(onClick = onClick)
             .padding(
                 horizontal = 12.dp,
             ),
@@ -156,7 +166,9 @@ private fun TextSection(
                 style = NovixTheme.typography.label.small,
                 color = NovixTheme.colors.hint,
                 textAlign = TextAlign.Start,
-                modifier = Modifier.fillMaxWidth().align(Alignment.Start),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Start),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis
             )
@@ -172,7 +184,8 @@ private fun ActorItemPreview() {
             actorName = "Lee Jung-jae",
             characterName = "Character name",
             imageRes = R.drawable.frame1597883073,
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(16.dp),
+            onClick = {}
         )
     }
 }

--- a/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/HomeCard.kt
@@ -12,10 +12,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import com.london.imageharamblur.ui.ImageViewFilter
 import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.ThemePreviews
+import com.london.imageharamblur.ui.ImageViewFilter
 
 @Composable
 fun HomeCard(
@@ -28,10 +28,11 @@ fun HomeCard(
 ) {
 
     Box(
-        modifier = modifier
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .then(modifier)
             .fillMaxWidth()
             .aspectRatio(3f/4f)
-            .clip(RoundedCornerShape(12.dp))
             .border(
                 width = 1.dp,
                 color = NovixTheme.colors.stroke,

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -282,12 +282,12 @@ fun MovieDetailsContent(
                                 characterName = actor.characterName,
                                 imageRes = actor.profilePicture,
                                 modifier = Modifier
-                                    .defaultMinSize(minWidth = 296.dp)
-                                    .clickable {
-                                        movieDetailsContract.onActorClick(
-                                            actor.id
-                                        )
-                                    }
+                                    .defaultMinSize(minWidth = 296.dp),
+                                onClick = {
+                                    movieDetailsContract.onActorClick(
+                                        actor.id
+                                    )
+                                }
                             )
                         }
                     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -211,9 +210,8 @@ fun EpisodeDetailsScreenContent(
                         imageRes = member.profilePicture,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 6.dp)
-                            .clickable { onNavigateToCast(member.id) }
-
+                            .padding(horizontal = 16.dp, vertical = 6.dp),
+                        onClick = { onNavigateToCast(member.id) }
                     )
                 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -482,8 +482,8 @@ fun CastSection(
                     characterName = "${member.roles[0].character} - ${member.roles[0].episodeCount}",
                     imageRes = member.profileUrl.orEmpty(),
                     modifier = Modifier
-                        .widthIn(296.dp)
-                        .clickable { onNavigateToCast(member.id) }
+                        .widthIn(296.dp),
+                    onClick = { onNavigateToCast(member.id) }
                 )
             }
         }

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeCarouselSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeCarouselSection.kt
@@ -2,6 +2,7 @@ package com.london.presentation.feature.home
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,7 +20,6 @@ import com.london.designsystem.component.carousel.isHero
 import com.london.designsystem.component.carousel.m3.CarouselState
 import com.london.designsystem.component.carousel.m3.rememberCarouselState
 import com.london.designsystem.theme.NovixTheme
-import com.london.designsystem.theme.noRippleClickable
 import com.london.designsystem.utils.string
 import com.london.domain.entity.recent.MediaType
 
@@ -60,12 +60,6 @@ fun HomeCarouselSection(
             val mediaItem = uiMediaList[index]
             HomeCard(
                 modifier = Modifier
-                    .noRippleClickable {
-                        onCardClick(
-                            mediaItem.id,
-                            mediaItem.mediaType
-                        )
-                    }
                     .maskClip(RoundedCornerShape(HomeCarouselDefaults.CARD_CORNER_RADIUS))
                     .maskBorder(
                         border = BorderStroke(
@@ -73,7 +67,12 @@ fun HomeCarouselSection(
                             color = NovixTheme.colors.stroke
                         ),
                         shape = RoundedCornerShape(HomeCarouselDefaults.CARD_CORNER_RADIUS)
-                    ),
+                    ).clickable {
+                        onCardClick(
+                            mediaItem.id,
+                            mediaItem.mediaType
+                        )
+                    },
                 imageUrl = mediaItem.posterUrl,
                 onSaveClick = { onSaveClick(mediaItem.id) },
                 hasSaveIcon = isHero

--- a/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
@@ -143,16 +143,14 @@ fun PopularSection(
 
                         transformOrigin = TransformOrigin(TRANSFORM_ORIGIN_X, TRANSFORM_ORIGIN_Y)
                     }
-                    .clickable(
-                        indication = null,
-                        interactionSource = null
-                    ) { onCardClick() },
+                    ,
             ) {
 
                 HomeCard(
                     imageUrl = images[page],
                     onSaveClick = { onSaveClick() },
-                    hasSaveIcon = pagerState.currentPage == page
+                    hasSaveIcon = pagerState.currentPage == page,
+                    modifier = Modifier.clickable{ if (pagerState.currentPage == page) onCardClick() }
                 )
                 if (pagerState.currentPage == page)
                     Column(

--- a/presentation/src/main/java/com/london/presentation/feature/home/TrendingSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/TrendingSection.kt
@@ -140,6 +140,7 @@ private fun CategoryCard(
                 brush = gradient,
                 shape = RoundedCornerShape(12.dp)
             )
+            .clip(RoundedCornerShape(12.dp))
             .clickable(onClick = onClick),
         contentAlignment = Alignment.BottomCenter
     ) {

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
@@ -1,7 +1,6 @@
 package com.london.presentation.feature.home.trending.actor
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -75,10 +74,10 @@ private fun TrendingActorsContent(
             pagingItems = actorsLazyItems,
         ) { actor ->
             ActorItem(
-                modifier = Modifier.clickable { contract.onActorClick(actor.id) },
                 actorName = actor.name,
                 characterName = null,
-                imageRes = actor.profilePicture
+                imageRes = actor.profilePicture,
+                onClick = {contract.onActorClick(actor.id)}
             )
         }
     }

--- a/presentation/src/main/java/com/london/presentation/shared/ActorsLayout.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/ActorsLayout.kt
@@ -1,6 +1,5 @@
 package com.london.presentation.shared
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,10 +28,10 @@ fun ActorsLayout(
             val actor = items[index]
             if (actor != null) {
                 ActorItem(
-                    modifier = Modifier.clickable(onClick = { onActorClick(actor) }),
                     actorName = actor.name,
                     characterName = null,
-                    imageRes = actor.profilePicture
+                    imageRes = actor.profilePicture,
+                    onClick = { onActorClick(actor) }
                 )
             }
         }


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
- Made the entire `ActorItem` clickable by adding an `onClick` parameter and applying the `clickable` modifier to relevant components within `ActorItem`.
- Updated various screens that use `ActorItem` to pass the appropriate `onClick` handler.
- Improved the visual design of `ActorItem` by applying a `clip` modifier to the `TextSection` for rounded corners.
- Ensured consistent click behavior across different sections of the app by replacing `noRippleClickable` with the standard `clickable` modifier where appropriate and ensuring the click area is correctly defined for `HomeCard`.
- Added a clip modifier to `TrendingSection`'s `CardTrendingItem` for consistency.
- Reordered modifiers in `HomeCard` to ensure the clip is applied before other modifiers that might affect its bounds.
## Type of Change
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Screenshots
<!-- Add if UI changes -->

<img width="532" height="146" alt="Screenshot 2025-07-30 185617" src="https://github.com/user-attachments/assets/b3e0506a-5b64-4d40-a9b4-72fe9ce8a39a" />
<img width="527" height="148" alt="Screenshot 2025-07-30 185605" src="https://github.com/user-attachments/assets/b4f8d4b1-c32c-4436-a397-e16fb08d1704" />
<img width="541" height="311" alt="Screenshot 2025-07-30 185552" src="https://github.com/user-attachments/assets/2299d275-6f77-46bc-a2e7-91903d172ea4" />
<img width="488" height="409" alt="Screenshot 2025-07-30 185541" src="https://github.com/user-attachments/assets/e606fc35-74fb-4096-be2b-674527a66499" />
<img width="526" height="421" alt="Screenshot 2025-07-30 185533" src="https://github.com/user-attachments/assets/752318b6-f651-4448-8dd6-c69488baec9b" />
<img width="455" height="538" alt="Screenshot 2025-07-30 185523" src="https://github.com/user-attachments/assets/bd063fed-1c1e-4085-a9d3-7783d0b66e93" />
