### PR TITLE
feat: HomeScreen: Add separate loader for top rated media section

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/home/CarousalShimmer.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/CarousalShimmer.kt
@@ -49,7 +49,7 @@ fun CarousalShimmerEffect(
             )
 
             Box(modifier = Modifier
-                .height(240.dp)
+                .height(210.dp)
                 .clip(RoundedCornerShape(12.dp))
                 .weight(0.5f)
                 .shimmerEffect()

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -242,7 +242,7 @@ private fun Content(
             }
 
             item(span = { GridItemSpan(maxLineSpan) }) {
-                if (!isLoading)
+                if (!uiState.isTopRatedLoading)
                     TopRatedSection(
                         uiState = uiState,
                         homeScreenContract = homeScreenContract,

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenUiState.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 data class HomeScreenUiState(
     val isLoading: Boolean = false,
     val error: ErrorState? = null,
+    val isTopRatedLoading: Boolean = false,
     val popularMovies: List<PopularMovie> = emptyList(),
     val popularTvShows: List<PopularTvShow> = emptyList(),
     val topRatedUiMediaList: List<HomeUiMedia> = emptyList(),

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
@@ -52,7 +52,7 @@ class HomeViewModel(
                 val shows = getTopRatedTvShows.invoke(pageNumber = 1)
                 Pair(movies, shows)
             },
-            onStart = { updateState { copy(isLoading = true) } },
+            onStart = { updateState { copy(isTopRatedLoading  = true) } },
             onSuccess = { (movies, shows) ->
                 val topRatedMedia = movies.items.take(10).toUiMedia() +
                         shows.items.take(10).toUiMedia()
@@ -62,7 +62,7 @@ class HomeViewModel(
                 }
             },
             onError = { errorState -> updateState { copy(error = errorState) } },
-            onCompleted = { updateState { copy(isLoading = false) } },
+            onCompleted = { updateState { copy(isTopRatedLoading  = false) } },
             checkSuccess = { (movies, shows) ->
                 movies.items.isNotEmpty() || shows.items.isNotEmpty()
             }


### PR DESCRIPTION
# What does this PR do?

This PR  introduces a new loading state `isTopRatedLoading` in `HomeScreenUiState` to manage the loading indicator specifically for the top-rated media section.

- Updated `HomeViewModel` to use `isTopRatedLoading` when fetching top-rated movies and TV shows.
- Modified `HomeScreen` to display the `TopRatedSection` only when `isTopRatedLoading` is false.
- Adjusted the height of the shimmer effect in `CarousalShimmer` from 240.dp to 210.dp.

