### PR TITLE
feat: Store movieId in MovieDetailsViewModel state

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
@@ -76,6 +76,7 @@ class MovieDetailsViewModel(
                 val (details, images, cast) = triple
                 updateState {
                     copy(
+                        movieId = details.id,
                         movieName = details.title,
                         movieGenres = details.genresId,
                         movieRating = details.voteAverage,


### PR DESCRIPTION
# What does this PR do?

This PR modifies the `MovieDetailsViewModel` to store the `movieId` within its state.

Previously, only movie details like name, genres, and rating were stored. Now, the `movieId` from the fetched movie details is also explicitly included in the view model's state.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
