### PR TITLE
feat: Update CircularLoading component with wavy animation

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/CircularLoading.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/CircularLoading.kt
@@ -7,55 +7,70 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.london.designsystem.theme.NovixTheme
+import kotlin.math.cos
+import kotlin.math.sin
 
 @Composable
 fun CircularLoading(
     modifier: Modifier = Modifier,
-    color: Color = NovixTheme.colors.secondary
 ) {
-    val infiniteTransition = rememberInfiniteTransition(label = "circular_loading")
-    val rotation by infiniteTransition.animateFloat(
+    val infiniteTransition = rememberInfiniteTransition(label = "wavy")
+    val progress by infiniteTransition.animateFloat(
         initialValue = 0f,
-        targetValue = 360f,
+        targetValue = 1f,
         animationSpec = infiniteRepeatable(
-            animation = tween(1000, easing = LinearEasing),
+            animation = tween(2000, easing = LinearEasing),
             repeatMode = RepeatMode.Restart
         ),
-        label = "rotation"
+        label = "progress"
     )
 
-    Box(
-        modifier = Modifier
-    ) {
-        Canvas(
-            modifier = modifier
-                .size(32.dp)
-                .rotate(rotation)
-        )
-        {
-            val strokeWidth = 3.dp.toPx()
+    val stroke = NovixTheme.colors.stroke
+    val primaryColor = NovixTheme.colors.primary
 
-            drawArc(
-                color = color,
-                startAngle = 0f,
-                sweepAngle = 300f,
-                useCenter = false,
-                style = Stroke(
-                    width = strokeWidth,
-                    cap = StrokeCap.Round
-                )
-            )
+    Canvas(modifier = modifier.size(48.dp)) {
+        val radius = size.minDimension / 2 - 8.dp.toPx()
+        val center = Offset(size.width / 2, size.height / 2)
+        val sweepAngle = 360f * progress
+
+        drawCircle(
+            color = stroke,
+            radius = radius,
+            center = center,
+            style = Stroke(4.dp.toPx())
+        )
+
+        val path = Path()
+        for (angle in 0..sweepAngle.toInt() step 2) {
+            val waveRadius = radius + 4f * sin(Math.toRadians(angle * 7.0)).toFloat()
+            val radians = Math.toRadians((angle - 90).toDouble())
+            val x = center.x + waveRadius * cos(radians).toFloat()
+            val y = center.y + waveRadius * sin(radians).toFloat()
+
+            if (angle == 0) path.moveTo(x, y) else path.lineTo(x, y)
         }
+
+        drawPath(
+            path = path,
+            color = primaryColor,
+            style = Stroke(4.dp.toPx(), cap = StrokeCap.Round)
+        )
     }
+}
+
+@Preview
+@Composable
+private fun Preview() {
+    CircularLoading()
 }


### PR DESCRIPTION
# What does this PR do?
The CircularLoading component has been updated to display a wavy animation instead of a simple rotating arc.

Key changes:
- Replaced the rotating arc with a path that draws a wavy line around a central circle.
- The animation now uses a progress value to control the length of the wavy line.
- The colors are now sourced from `NovixTheme.colors.stroke` and `NovixTheme.colors.primary`.
- The size of the component is now fixed at 48.dp.
- Added a Preview composable for easier visualization.

## Type of Change
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Screenshots
https://github.com/user-attachments/assets/aba86a2d-679b-44f7-99d6-230b377eaf36


## Checklist
- [ ] Code builds without warnings
- [ ] Self-reviewed
- [ ] Tests pass
- [x] Ready for review
