### PR TITLE
fix: Use posterUrl as fallback for empty movie images

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
@@ -83,7 +83,7 @@ class MovieDetailsViewModel(
                         movieDuration = details.runtime.toString(),
                         releaseDate = details.releaseDate,
                         movieOverview = details.overview,
-                        movieImages = images,
+                        movieImages = images.ifEmpty { listOf(details.posterUrl) },
                         actors = cast
                     )
 


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Checklist
- [ ] Code builds without warnings
- [ ] Self-reviewed
- [ ] Tests pass
- [x] Ready for review
