### PR TITLE
feat: Localize numbers and add "no reviews" string

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
@@ -65,6 +65,7 @@ import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.offsetLayout
+import com.london.presentation.utils.toLocalizedNumbers
 import kotlinx.coroutines.delay
 import org.koin.androidx.compose.koinViewModel
 
@@ -421,7 +422,7 @@ private fun ActorInfoSection(
             )
             TextWithIcon(
                 icon = painterResource(R.drawable.birthday_cake),
-                text = if (deathDay != "") "$birthday  -  $deathDay" else birthday,
+                text = if (deathDay != "") "${birthday.toLocalizedNumbers()}  -  ${deathDay.toLocalizedNumbers()}" else birthday.toLocalizedNumbers(),
             )
         }
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -351,7 +351,7 @@ private fun RatingAndMetaRow(
                 icon = drawable.star,
                 contentDesc = stringResource(star),
                 tint = NovixTheme.colors.yellowAccent,
-                text = rate,
+                text = rate.toLocalizedNumbers(),
                 textColor = NovixTheme.colors.body
             )
         }
@@ -376,7 +376,7 @@ private fun RatingAndMetaRow(
         }
 
         if (
-            (!time.isNullOrBlank() && !date.isNullOrBlank()) ||
+            (time.toLocalizedNumbers().isNotBlank() && date.toLocalizedNumbers().isNotBlank()) ||
             (rate.isNullOrBlank() && !time.isNullOrBlank() && !date.isNullOrBlank())
         ) {
             Dot()

--- a/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/PopularSection.kt
@@ -33,6 +33,7 @@ import com.london.designsystem.component.Text
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
 import com.london.presentation.shared.RatingItem
+import com.london.presentation.utils.toLocalizedNumbers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -173,7 +174,7 @@ fun PopularSection(
                             horizontalArrangement = if (isRtl) Arrangement.End else Arrangement.Start
                         ) {
                             RatingItem(
-                                rating = cardRating,
+                                rating = cardRating.toLocalizedNumbers(),
                                 color = NovixTheme.colors.onPrimary
                             )
                         }

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
@@ -255,7 +255,7 @@ fun AuthorItem(
 @Composable
 fun EmptyReviews(
     modifier: Modifier = Modifier,
-    text: String = "there is no review"
+    text: String = stringResource(R.string.no_reviews)
 ) {
     Column(
         modifier = modifier

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -103,4 +103,5 @@
     <string name="reviews">المراجعات</string>
     <string name="no_recent_history">لم تتفقد أي شيء بعد.\nخذ جولة في التطبيق ثم عُدّ مجددًا! </string>
     <string name="no_tv_shows_found">لا يوجد مسلسلات في هذا التصنيف حاليا</string>
+    <string name="no_reviews">"لا يوجد مراجعات"</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -103,4 +103,5 @@
     <string name="no_tv_shows_found">no tv shows found in this category</string>
     <string name="reviews">Reviews</string>
     <string name="no_recent_history">Looks like you haven\'t checked anything yet.\nTake a look around and come back!</string>
+    <string name="no_reviews">\"There is no review\"</string>
 </resources>


### PR DESCRIPTION
# What does this PR do?

This PR introduces number localization for Arabic and adds a new string resource for "no reviews" in both English and Arabic.

Specifically, the changes are:
- ActorDetailsScreen: Localized birthday and death day numbers.
- MovieDetailsScreen: Localized movie rating, time, and date numbers.
- PopularSection: Localized card rating numbers.
- ReviewsScreen: Used the new "no_reviews" string resource.
- Added "no_reviews" string to `values/strings.xml` and `values-ar/strings.xml`.
