### PR TITLE
Hotfix/hide rating if zero

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -1,4 +1,5 @@
 package com.london.presentation.feature.details.movieDetalis
+
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
@@ -74,6 +75,7 @@ import com.london.presentation.shared.FooterSection
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertGenreCodeToString
 import com.london.presentation.utils.getLocalizedTimeUnit
+import com.london.presentation.utils.isNotZeroRate
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.openUrl
 import com.london.presentation.utils.reverseDateFormat
@@ -346,7 +348,7 @@ private fun RatingAndMetaRow(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (!rate.isNullOrBlank()) {
+        if (!rate.isNullOrBlank() && rate.isNotZeroRate() ) {
             IconWithText(
                 icon = drawable.star,
                 contentDesc = stringResource(star),

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
@@ -55,6 +55,7 @@ import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.FooterSection
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.isNotZeroRate
 import com.london.presentation.utils.openUrl
 import com.london.presentation.utils.toLocalizedNumbers
 import org.koin.androidx.compose.koinViewModel
@@ -277,10 +278,12 @@ fun TvShowBasicDetails(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        RatingItem(
-            modifier = Modifier,
-            rating = uiState.voteAverage.toLocalizedNumbers(),
-        )
+        if (uiState.voteAverage.isNotZeroRate()){
+            RatingItem(
+                modifier = Modifier,
+                rating = uiState.voteAverage.toLocalizedNumbers(),
+            )
+        }
 
         Box(
             modifier = Modifier

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -71,6 +70,7 @@ import com.london.presentation.shared.FooterSection
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertDate
+import com.london.presentation.utils.isNotZeroRate
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.openUrl
 import com.london.presentation.utils.reverseDateFormat
@@ -410,10 +410,11 @@ fun TvShowBasicDetails(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        RatingItem(
-            modifier = Modifier,
-            rating = rating
-        )
+        if (rating.isNotBlank() && rating.isNotZeroRate()) {
+            RatingItem(
+                rating = rating
+            )
+        }
 
         Box(
             modifier = Modifier
@@ -640,18 +641,20 @@ private fun EpisodeItem(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(4.dp)
             ) {
-                RatingItem(
-                    rating = episode.voteAverage.toLocalizedNumbers(),
-                    color = NovixTheme.colors.hint
-                )
+                if (episode.voteAverage.isNotZeroRate()){
+                    RatingItem(
+                        rating = episode.voteAverage.toLocalizedNumbers(),
+                        color = NovixTheme.colors.hint
+                    )
 
-                Box(
-                    modifier = Modifier
-                        .padding(horizontal = 8.dp)
-                        .size(3.dp)
-                        .clip(CircleShape)
-                        .background(NovixTheme.colors.hint)
-                )
+                    Box(
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                            .size(3.dp)
+                            .clip(CircleShape)
+                            .background(NovixTheme.colors.hint)
+                    )
+                }
 
                 if (episode.runtime != null) {
                     EpisodeDuration(episode.runtime.toString().toLocalizedNumbers())

--- a/presentation/src/main/java/com/london/presentation/utils/Utils.kt
+++ b/presentation/src/main/java/com/london/presentation/utils/Utils.kt
@@ -108,3 +108,12 @@ fun reverseDateFormat(input: String): String {
 fun String?.getValueOf(key: String): String? {
     return this
 }
+
+fun String.isNotZeroRate() = runCatching {
+    this != "0.0" && this != "٠٫٠"
+}.getOrDefault(false)
+
+fun Double.isNotZeroRate() = runCatching {
+    this != 0.0
+}.getOrDefault(false)
+


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
- Added `isNotZeroRate()` extension functions for `String` and `Double` in `Utils.kt` to check if a rating value is not zero.
- Updated `MovieDetailsScreen.kt`, `TvShowDetailsScreen.kt`, and `EpisodeDetailsScreen.kt` to utilize the `isNotZeroRate()` function to conditionally display the rating.
## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
