### PR TITLE
fix: refactor start padding in top rated and continue watching

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/continuewatching/ContinueWatchingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/continuewatching/ContinueWatchingScreen.kt
@@ -78,7 +78,6 @@ fun Content(
             .background(color = NovixTheme.colors.surface)
             .padding(WindowInsets.statusBars.asPaddingValues())
             .padding(WindowInsets.navigationBars.asPaddingValues())
-
     ) {
         TopBar(
             modifier = Modifier

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeCarouselSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeCarouselSection.kt
@@ -49,13 +49,15 @@ fun HomeCarouselSection(
 
         HeroCarousel(
             modifier = Modifier
-                .height(HomeCarouselDefaults.CAROUSEL_HEIGHT)
-                .padding(start = HomeCarouselDefaults.CAROUSEL_START_PADDING),
+                .height(HomeCarouselDefaults.CAROUSEL_HEIGHT),
             carouselState = carouselState,
             heroItemSize = HomeCarouselDefaults.HERO_ITEM_SIZE,
             smallItemSize = HomeCarouselDefaults.SMALL_ITEM_SIZE,
             itemSpacing = HomeCarouselDefaults.ITEM_SPACING,
-            contentPadding = PaddingValues(end = HomeCarouselDefaults.CONTENT_END_PADDING)
+            contentPadding = PaddingValues(
+                start = HomeCarouselDefaults.CAROUSEL_START_PADDING,
+                end = HomeCarouselDefaults.CONTENT_END_PADDING
+            )
         ) { index ->
             val mediaItem = uiMediaList[index]
             HomeCard(


### PR DESCRIPTION

# What does this PR do?
<!-- Brief description of changes -->
refactor start padding in top rated and continue watching sections in home screen

## Type of Change
- [x] 🐛 Bug fix