### PR TITLE
fix: network error screen

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
@@ -6,11 +6,12 @@ import androidx.compose.runtime.Composable
 fun BuildScreen(
     isLoading: Boolean = false,
     isError: Boolean = false,
-    content: @Composable () -> Unit
+    onBack: () -> Unit,
+    content: @Composable () -> Unit,
 ) {
     when{
         isLoading -> LoadingScreen()
-        isError -> NetworkErrorScreen()
+        isError -> NetworkErrorScreen(onBack = onBack)
         else -> content()
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/buildscreen/NetworkErrorScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/buildscreen/NetworkErrorScreen.kt
@@ -2,10 +2,12 @@ package com.london.presentation.feature.buildscreen
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,6 +17,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.london.designsystem.R
 import com.london.designsystem.component.Text
+import com.london.designsystem.component.TopBar
 import com.london.designsystem.component.button.OutlineButton
 import com.london.designsystem.theme.NovixTheme
 
@@ -22,44 +25,57 @@ import com.london.designsystem.theme.NovixTheme
 fun NetworkErrorScreen(
     modifier: Modifier = Modifier,
     onRetry: () -> Unit = {},
+    onBack: (() -> Unit)?
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
+    Box(
+        modifier
+            .statusBarsPadding()
+            .padding(horizontal = 16.dp)
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.image_no_internet),
-            contentDescription = stringResource(R.string.no_internet),
+        if (onBack != null) {
+            TopBar(
+                onBackClick = onBack,
+            )
+        }
+
+        Column(
             modifier = Modifier
-                .padding(bottom = 16.dp)
-                .size(82.dp, 64.dp)
-        )
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.image_no_internet),
+                contentDescription = stringResource(R.string.no_internet),
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .size(82.dp, 64.dp)
+            )
 
-        Text(
-            text = stringResource(R.string.you_are_offline),
-            style = NovixTheme.typography.title.medium,
-            color = NovixTheme.colors.title,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
+            Text(
+                text = stringResource(R.string.you_are_offline),
+                style = NovixTheme.typography.title.medium,
+                color = NovixTheme.colors.title,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
 
-        Text(
-            text = stringResource(R.string.check_your_connection),
-            style = NovixTheme.typography.body.small,
-            color = NovixTheme.colors.body,
-            textAlign = TextAlign.Center
-        )
-        OutlineButton(
-            text = stringResource(com.london.presentation.R.string.retry),
-            hasLabel = true,
-            icon = null,
-            hasIcon = false,
-            isLoading = false,
-            onClick = onRetry,
-            modifier = Modifier.padding(top = 16.dp)
-        )
+            Text(
+                text = stringResource(R.string.check_your_connection),
+                style = NovixTheme.typography.body.small,
+                color = NovixTheme.colors.body,
+                textAlign = TextAlign.Center
+            )
+            OutlineButton(
+                text = stringResource(com.london.presentation.R.string.retry),
+                hasLabel = true,
+                icon = null,
+                hasIcon = false,
+                isLoading = false,
+                onClick = onRetry,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+        }
     }
+
 }

--- a/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
@@ -17,8 +17,6 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
 import com.london.domain.entity.Movie
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
@@ -45,16 +43,16 @@ fun MoviesByCategoryScreen(
         }
     }
 
-    BuildScreen {
-        when {
-            state.isLoading -> LoadingScreen()
-            state.error != null -> NetworkErrorScreen()
-            else -> MoviesByCategoryContent(
+    BuildScreen(
+        onBack = viewModel::onBack,
+        isLoading = state.isLoading,
+        isError = state.error != null
+    ) {
+        MoviesByCategoryContent(
                 state = state,
                 contract = viewModel,
                 modifier = modifier,
             )
-        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
@@ -17,8 +17,6 @@ import com.london.designsystem.theme.ThemePreviews
 import com.london.domain.entity.TvShow
 import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
@@ -42,15 +40,15 @@ fun TvShowByCategoryScreen(
             )
         }
     }
-    BuildScreen {
-        when {
-            state.isLoading -> LoadingScreen()
-            state.error != null -> NetworkErrorScreen()
-            else -> Content(
+    BuildScreen(
+        onBack = viewModel::onBack,
+        isLoading = state.isLoading,
+        isError = state.error != null
+    ) {
+             Content(
                 state = state,
                 contract = viewModel,
             )
-        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryScreen.kt
@@ -30,10 +30,7 @@ import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.imageharamblur.ui.ImageViewFilter
 import com.london.presentation.R
-import com.london.presentation.feature.base.ErrorState
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.utils.Listen
 import org.koin.androidx.compose.koinViewModel
 
@@ -47,15 +44,15 @@ fun ActorGalleryScreen(
 
     effect.Listen<ActorGalleryEffectUiState> { onNavigateBack() }
 
-    BuildScreen {
-        when {
-            uiState.isLoading -> LoadingScreen()
-            uiState.error == ErrorState.NoInternet -> NetworkErrorScreen()
-            else -> Content(
-                actorGalleryContract = viewModel,
-                uiState = uiState
-            )
-        }
+    BuildScreen(
+        onBack = viewModel::onBackClick,
+        isLoading = uiState.isLoading,
+        isError = uiState.error != null
+    ) {
+        Content(
+            actorGalleryContract = viewModel,
+            uiState = uiState
+        )
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.utils.Listen
 import org.koin.androidx.compose.koinViewModel
@@ -28,15 +26,17 @@ fun TopMoviesPicksScreen(
         onNavigateMovie = onNavigateMovie,
         onNavigateBack = onNavigateBack
     )
-    BuildScreen {
-        when {
-            state.isSaved -> LoadingScreen()
-            state.errorState != null -> NetworkErrorScreen()
-            else -> TopMoviesPicksContent(
-                state = state,
-                contract = viewModel,
-            )
-        }
+    BuildScreen(
+        onBack = viewModel::onBack,
+        isLoading = state.isLoading,
+        isError = state.errorState != null
+    ) {
+
+        TopMoviesPicksContent(
+            state = state,
+            contract = viewModel,
+        )
+
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.utils.Listen
 import org.koin.androidx.compose.koinViewModel
@@ -29,15 +27,17 @@ fun TopTvShowsPicksScreen(
         onNavigateBack = onNavigateBack
     )
 
-    BuildScreen {
-        when {
-            state.isSaved -> LoadingScreen()
-            state.errorState != null -> NetworkErrorScreen()
-            else -> TopTvShowsPicksContent(
-                state = state,
-                contract = viewModel,
-            )
-        }
+    BuildScreen(
+        onBack = viewModel::onBack,
+        isLoading = state.isLoading,
+        isError = state.errorState != null
+    ) {
+
+        TopTvShowsPicksContent(
+            state = state,
+            contract = viewModel,
+        )
+
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -65,8 +65,6 @@ import com.london.presentation.R.string.star
 import com.london.presentation.R.string.time_icon
 import com.london.presentation.R.string.view_reviews
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.feature.reviews.MediaType
 import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.ConditionalText
@@ -103,15 +101,15 @@ fun MovieDetailsScreen(
         onNavigateToReviews = onNavigateToReviews
     )
 
-    BuildScreen {
-        when {
-            state.isLoading -> LoadingScreen()
-            state.error != null -> NetworkErrorScreen()
-            else -> MovieDetailsContent(
-                uiState = state,
-                movieDetailsContract = viewModel
-            )
-        }
+    BuildScreen(
+        onBack = viewModel::onBackClick,
+        isLoading = state.isLoading,
+        isError = state.error != null
+    ) {
+        MovieDetailsContent(
+            uiState = state,
+            movieDetailsContract = viewModel
+        )
     }
 }
 
@@ -348,7 +346,7 @@ private fun RatingAndMetaRow(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        if (!rate.isNullOrBlank() && rate.isNotZeroRate() ) {
+        if (!rate.isNullOrBlank() && rate.isNotZeroRate()) {
             IconWithText(
                 icon = drawable.star,
                 contentDesc = stringResource(star),
@@ -382,7 +380,8 @@ private fun RatingAndMetaRow(
                 textColor = NovixTheme.colors.body
             )
         }
-        val showDot = !time.isNullOrBlank() && time != "0" && !date.isNullOrBlank() && !rate.isNullOrBlank()
+        val showDot =
+            !time.isNullOrBlank() && time != "0" && !date.isNullOrBlank() && !rate.isNullOrBlank()
 
         if (showDot) {
             Box(

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
@@ -78,16 +78,16 @@ fun EpisodeDetailsScreen(
     }
 
     BuildScreen(
+        onBack = viewModel::onBackClicked,
         isLoading = uiState.isLoading,
-        isError = false,
-        content = {
-            EpisodeDetailsScreenContent(
-                uiState = uiState,
-                episodeDetailsContract = viewModel,
-                onNavigateToCast = onNavigateToCast
-            )
-        }
-    )
+        isError = uiState.error != null
+    ) {
+        EpisodeDetailsScreenContent(
+            uiState = uiState,
+            episodeDetailsContract = viewModel,
+            onNavigateToCast = onNavigateToCast
+        )
+    }
 }
 
 @Composable
@@ -278,7 +278,7 @@ fun TvShowBasicDetails(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        if (uiState.voteAverage.isNotZeroRate()){
+        if (uiState.voteAverage.isNotZeroRate()) {
             RatingItem(
                 modifier = Modifier,
                 rating = uiState.voteAverage.toLocalizedNumbers(),

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -113,15 +113,15 @@ fun TvShowsDetailsScreen(
     }
 
     BuildScreen(
+        onBack = viewModel::onBackClicked,
         isLoading = uiState.isLoading,
-        isError = false,
-        content = {
-            TvShowsDetailScreenContent(
-                uiState = uiState,
-                tvShowDetailsContract = viewModel
-            )
-        }
-    )
+        isError = uiState.error != null
+    ) {
+        TvShowsDetailScreenContent(
+            uiState = uiState,
+            tvShowDetailsContract = viewModel
+        )
+    }
 }
 
 @Composable

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -105,7 +105,7 @@ fun HomeScreen(
         with(LocalDensity.current) { LocalWindowInfo.current.containerSize.width.toDp() }
 
     when{
-        uiState.error != null -> NetworkErrorScreen()
+        uiState.error != null -> NetworkErrorScreen(onBack = null)
         else ->
             Box(
             modifier = Modifier

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
@@ -45,8 +45,6 @@ import com.london.designsystem.theme.NovixTheme
 import com.london.imageharamblur.ui.ImageViewFilter
 import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
-import com.london.presentation.feature.buildscreen.LoadingScreen
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.shared.ReviewsDate
@@ -64,15 +62,15 @@ fun ReviewsScreen(
 
     effect?.Listen { onNavigateBack() }
 
-    BuildScreen {
-        when {
-            uiState.isLoading -> LoadingScreen()
-            uiState.error != null -> NetworkErrorScreen()
-            else -> ReviewsScreenContent(
-                uiState = uiState,
-                reviewContract = viewModel,
-            )
-        }
+    BuildScreen(
+        isLoading = uiState.isLoading,
+        isError = uiState.error != null,
+        onBack = onNavigateBack,
+    ) {
+        ReviewsScreenContent(
+            uiState = uiState,
+            reviewContract = viewModel,
+        )
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -116,7 +116,7 @@ fun SearchScreen(
     }
 
     when{
-        state.error is ErrorState.NoInternet -> NetworkErrorScreen()
+        state.error is ErrorState.NoInternet -> NetworkErrorScreen(onBack = null)
         else ->
             SearchScreenContent(
                 state = state,
@@ -239,7 +239,8 @@ fun SearchScreenContent(
                                         state.searchQuery.text,
                                         state.selectedCategory
                                     )
-                                }
+                                },
+                                onBack = null
                             )
                         } else {
                             when (state.selectedCategory) {
@@ -659,7 +660,8 @@ private fun SearchContentWithErrorHandling(
                     state.searchQuery.text,
                     state.selectedCategory
                 )
-            }
+            },
+            onBack = null
         )
     } else {
         content(isLoading)

--- a/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
@@ -29,7 +29,7 @@ fun <T : Any> LazyPagingColumn(
 ) {
     when {
         pagingItems.loadState.refresh is LoadState.Error -> NetworkErrorScreen(
-            onRetry = onRetry
+            onRetry = onRetry, onBack = null
         )
 
         pagingItems.isLoading() -> CircularLoading(

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
@@ -40,7 +40,7 @@ fun <T : Any> MediaLazyPagingGrid(
 ) {
     when {
         pagingFlow.loadState.refresh is LoadState.Error -> NetworkErrorScreen(
-            onRetry = onRetry
+            onRetry = onRetry, onBack = null
         )
 
         pagingFlow.isLoading() -> CircularLoading(


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
The `BuildScreen` composable has been updated to accept an `onBack` parameter, which is then passed to the `NetworkErrorScreen`. This change ensures that the back navigation functionality is available across various screens that utilize the `BuildScreen` for error and loading state management.

Additionally, several screens have been refactored to utilize the updated `BuildScreen` and provide the necessary `onBack` callback. The `onBack` parameter in `NetworkErrorScreen` calls within `HomeScreen` and `SearchScreen` has been set to `null` as these screens do not require a back button in the error state.
## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI
