### PR TITLE
fix: prevent navigation to current destination

### DIFF
--- a/app/src/main/java/com/london/app/navigation/NovixApp.kt
+++ b/app/src/main/java/com/london/app/navigation/NovixApp.kt
@@ -506,6 +506,10 @@ private fun navigateToBottomBarDestination(
     navController: NavHostController,
     destination: Screen
 ) {
+    if (navController.currentBackStackEntry?.destination?.hasRoute(destination::class) == true) {
+        return
+    }
+
     navController.navigate(destination) {
         popUpTo(navController.graph.findStartDestination().id) {
             saveState = true


### PR DESCRIPTION
# What does this PR do?

This change adds a check to `navigateToScreen` in `NovixApp.kt` to prevent navigating to the same destination if it's already the current route.

