### PR TITLE
Refactor: Standardize error and loading states with BuildScreen

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
@@ -7,6 +7,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import com.london.designsystem.component.EmptyLayout
+import com.london.presentation.utils.isEmpty
+import com.london.presentation.utils.isNotEmpty
+import com.london.presentation.utils.isNotNull
+import com.london.presentation.utils.shouldShowLoading
 
 
 @Composable
@@ -22,18 +26,22 @@ fun BuildScreen(
     content: @Composable () -> Unit,
 ) {
     when {
-        isLoading || (handlePagingLoadingAutomatically && pagingFlow?.loadState?.refresh is LoadState.Loading) -> {
-            LoadingScreen()
-        }
+        shouldShowLoading(
+            isLoading = isLoading,
+            handlePagingLoadingAutomatically = handlePagingLoadingAutomatically,
+            pagingFlow = pagingFlow
+        ) -> { LoadingScreen() }
+
         isError || (pagingFlow?.loadState?.refresh is LoadState.Error) -> {
             NetworkErrorScreen(onBack = onBack, onRetry = onRetry)
         }
-        pagingFlow != null &&
-                pagingFlow.itemCount == 0 &&
+
+        pagingFlow?.isNotEmpty() == true &&
+                pagingFlow.isEmpty() &&
                 pagingFlow.loadState.refresh is LoadState.NotLoading &&
-                emptyLayoutMessage != null -> {
+                emptyLayoutMessage.isNotNull() -> {
             EmptyLayout(
-                text = stringResource(emptyLayoutMessage),
+                text = stringResource(emptyLayoutMessage!!),
                 image = emptyLayoutImage ?: 0
             )
         }

--- a/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/buildscreen/BuildScreen.kt
@@ -1,17 +1,44 @@
 package com.london.presentation.feature.buildscreen
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import com.london.designsystem.component.EmptyLayout
+
 
 @Composable
 fun BuildScreen(
     isLoading: Boolean = false,
     isError: Boolean = false,
     onBack: () -> Unit,
+    onRetry: () -> Unit = {},
+    @StringRes emptyLayoutMessage: Int? = null,
+    @DrawableRes emptyLayoutImage: Int? = null,
+    pagingFlow: LazyPagingItems<*>? = null,
+    handlePagingLoadingAutomatically: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    when{
-        isLoading -> LoadingScreen()
-        isError -> NetworkErrorScreen(onBack = onBack)
-        else -> content()
+    when {
+        isLoading || (handlePagingLoadingAutomatically && pagingFlow?.loadState?.refresh is LoadState.Loading) -> {
+            LoadingScreen()
+        }
+        isError || (pagingFlow?.loadState?.refresh is LoadState.Error) -> {
+            NetworkErrorScreen(onBack = onBack, onRetry = onRetry)
+        }
+        pagingFlow != null &&
+                pagingFlow.itemCount == 0 &&
+                pagingFlow.loadState.refresh is LoadState.NotLoading &&
+                emptyLayoutMessage != null -> {
+            EmptyLayout(
+                text = stringResource(emptyLayoutMessage),
+                image = emptyLayoutImage ?: 0
+            )
+        }
+        else -> {
+            content()
+        }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
@@ -23,6 +24,7 @@ import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertGenreCodeToString
+import com.london.presentation.utils.isLoading
 import kotlinx.coroutines.flow.flow
 
 @Composable
@@ -44,10 +46,13 @@ fun MoviesByCategoryScreen(
         }
     }
 
+    val moviesByCategory = state.movies.collectAsLazyPagingItems()
+
     BuildScreen(
         onBack = viewModel::onBack,
-        isLoading = state.isLoading,
-        isError = state.error != null
+        isLoading = moviesByCategory.isLoading(),
+        isError = moviesByCategory.loadState.refresh is LoadState.Error,
+        onRetry = moviesByCategory::refresh
     ) {
         MoviesByCategoryContent(
             state = state,

--- a/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/moviesbycategory/MoviesByCategoryScreen.kt
@@ -18,7 +18,6 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
 import com.london.domain.entity.Movie
-import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
@@ -93,7 +92,6 @@ private fun MoviesByCategoryContent(
                 .padding(horizontal = 16.dp),
             onSaveClick = { /* TODO: Implement save functionality */ },
             isItemSaved = { false },
-            noMediaMessage = R.string.no_trending_movies_in_genre
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
@@ -21,6 +22,7 @@ import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertGenreCodeToString
+import com.london.presentation.utils.isLoading
 
 @Composable
 fun TvShowByCategoryScreen(
@@ -39,10 +41,14 @@ fun TvShowByCategoryScreen(
             )
         }
     }
+
+    val tvShowByCategory = state.tvShowFlow.collectAsLazyPagingItems()
+
     BuildScreen(
         onBack = viewModel::onBack,
-        isLoading = state.isLoading,
-        isError = state.error != null
+        isLoading = tvShowByCategory.isLoading(),
+        isError = tvShowByCategory.loadState.refresh is LoadState.Error,
+        onRetry = tvShowByCategory::refresh
     ) {
         Content(
             state = state,

--- a/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/tvshowbycategory/TvShowByCategoryScreen.kt
@@ -16,7 +16,6 @@ import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
-import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.feature.search.SearchCategory
 import com.london.presentation.shared.MediaLazyPagingGrid
@@ -87,7 +86,6 @@ private fun Content(
                 .padding(horizontal = 16.dp),
             onSaveClick = { /* TODO: Implement save functionality */ },
             isItemSaved = { false },
-            noMediaMessage = R.string.no_tv_shows_found,
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
@@ -64,14 +64,12 @@ import com.london.domain.entity.actordetails.actorimage.ImageDetails
 import com.london.domain.entity.actordetails.actormovie.ActorMovieCastMemberEntity
 import com.london.domain.entity.actordetails.actortvshow.ActorTvShowCastMemberEntity
 import com.london.presentation.R
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.toLocalizedNumbers
-import androidx.hilt.navigation.compose.hiltViewModel
-import kotlinx.coroutines.delay
 
 @Composable
 fun ActorDetailsScreen(
@@ -97,10 +95,18 @@ fun ActorDetailsScreen(
         onNavigateToMoviePicks = onNavigateToMoviePicks
     )
 
-    ActorScreenContent(
-        uiState = uiState,
-        actorDetailsContract = viewModel
-    )
+    BuildScreen(
+        isLoading = uiState.isLoading,
+        isError = uiState.error != null,
+        onBack = viewModel::onNavigateBack,
+        onRetry = viewModel::onRetry
+
+    ) {
+        ActorScreenContent(
+            uiState = uiState,
+            actorDetailsContract = viewModel
+        )
+    }
 }
 
 
@@ -110,92 +116,81 @@ fun ActorScreenContent(
     uiState: ActorDetailsUiState,
     actorDetailsContract: ActorDetailsContract,
 ) {
-    when {
-        uiState.error != null -> NetworkErrorScreen(
-            onRetry = actorDetailsContract::onRetry,
-            onBack = actorDetailsContract::onNavigateBack,
-            modifier = Modifier.fillMaxSize()
-        )
 
-        uiState.isLoading -> CircularLoading()
+    val lazyState = rememberLazyListState()
+    val shouldShowBackground by remember {
+        derivedStateOf {
+            lazyState.firstVisibleItemScrollOffset > 40f || lazyState.firstVisibleItemIndex > 0
+        }
+    }
+    val backgroundAlpha by animateFloatAsState(
+        targetValue = if (shouldShowBackground) 1f else 0f,
+        animationSpec = tween(durationMillis = 400, easing = FastOutSlowInEasing),
+        label = "background_alpha"
+    )
 
-        else -> {
-            val lazyState = rememberLazyListState()
-            val shouldShowBackground by remember {
-                derivedStateOf {
-                    lazyState.firstVisibleItemScrollOffset > 40f || lazyState.firstVisibleItemIndex > 0
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(NovixTheme.colors.surface)
+    ) {
+        EmptyScreen(uiState)
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                bottom = WindowInsets.navigationBars.asPaddingValues()
+                    .calculateBottomPadding() + 16.dp
+            ),
+            state = lazyState
+        ) {
+            item {
+                if (hasOtherContent(uiState)) {
+                    uiState.actorImageDetails?.let { image ->
+                        CustomBackDropImagePager(
+                            images = image.map { it.fileUrl },
+                            isVisibleDots = false
+                        )
+                    }
                 }
             }
-            val backgroundAlpha by animateFloatAsState(
-                targetValue = if (shouldShowBackground) 1f else 0f,
-                animationSpec = tween(durationMillis = 400, easing = FastOutSlowInEasing),
-                label = "background_alpha"
-            )
 
-            Box(
-                modifier = modifier
-                    .fillMaxSize()
-                    .background(NovixTheme.colors.surface)
-            ) {
-                EmptyScreen(uiState)
-
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        bottom = WindowInsets.navigationBars.asPaddingValues()
-                            .calculateBottomPadding() + 16.dp
-                    ),
-                    state = lazyState
-                ) {
-                    item {
-                        if (hasOtherContent(uiState)) {
-                            uiState.actorImageDetails?.let { image ->
-                                CustomBackDropImagePager(
-                                    images = image.map { it.fileUrl },
-                                    isVisibleDots = false
-                                )
-                            }
-                        }
-                    }
-
-                    item { ActorInfoSectionItem(uiState = uiState) }
-                    item { BiographySection(uiState = uiState) }
-                    item {
-                        GallerySection(
-                            images = uiState.actorImageDetails,
-                            onGalleryClick = { actorDetailsContract.onGalleryClick(uiState.actorId) }
-                        )
-                    }
-                    item {
-                        MoviesSection(
-                            movies = uiState.actorMovieDetails?.cast,
-                            onMoviePicksClick = { actorDetailsContract.onMoviePicksClick(uiState.actorId) },
-                            onMovieScreenClick = actorDetailsContract::onMovieScreenClick
-                        )
-                    }
-                    item {
-                        TvShowsSection(
-                            tvShows = uiState.actorTvShowDetails?.cast,
-                            onTvShowPicksClick = { actorDetailsContract.onTvShowPicksClick(uiState.actorId) },
-                            onTvShowScreenClick = actorDetailsContract::onTvShowScreenClick
-                        )
-                    }
-                }
-
-                TopBar(
-                    onBackClick = actorDetailsContract::onNavigateBack,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(NovixTheme.colors.surface.copy(alpha = backgroundAlpha))
-                        .padding(
-                            start = 16.dp,
-                            top = WindowInsets.statusBars.asPaddingValues()
-                                .calculateTopPadding() + 12.dp
-                        )
-                        .zIndex(1f)
+            item { ActorInfoSectionItem(uiState = uiState) }
+            item { BiographySection(uiState = uiState) }
+            item {
+                GallerySection(
+                    images = uiState.actorImageDetails,
+                    onGalleryClick = { actorDetailsContract.onGalleryClick(uiState.actorId) }
+                )
+            }
+            item {
+                MoviesSection(
+                    movies = uiState.actorMovieDetails?.cast,
+                    onMoviePicksClick = { actorDetailsContract.onMoviePicksClick(uiState.actorId) },
+                    onMovieScreenClick = actorDetailsContract::onMovieScreenClick
+                )
+            }
+            item {
+                TvShowsSection(
+                    tvShows = uiState.actorTvShowDetails?.cast,
+                    onTvShowPicksClick = { actorDetailsContract.onTvShowPicksClick(uiState.actorId) },
+                    onTvShowScreenClick = actorDetailsContract::onTvShowScreenClick
                 )
             }
         }
+
+        TopBar(
+            onBackClick = actorDetailsContract::onNavigateBack,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(NovixTheme.colors.surface.copy(alpha = backgroundAlpha))
+                .padding(
+                    start = 16.dp,
+                    top = WindowInsets.statusBars.asPaddingValues()
+                        .calculateTopPadding() + 12.dp
+                )
+                .zIndex(1f)
+        )
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryContract.kt
@@ -2,4 +2,5 @@ package com.london.presentation.feature.details.actordetails.gallery
 
 interface ActorGalleryContract {
     fun onBackClick()
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryScreen.kt
@@ -47,7 +47,8 @@ fun ActorGalleryScreen(
     BuildScreen(
         onBack = viewModel::onBackClick,
         isLoading = uiState.isLoading,
-        isError = uiState.error != null
+        isError = uiState.error != null,
+        onRetry = viewModel::onRetry
     ) {
         Content(
             actorGalleryContract = viewModel,

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryViewModel.kt
@@ -43,7 +43,7 @@ class ActorGalleryViewModel @Inject constructor(
         )
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         updateState { copy(error = null) }
         loadImages(actorId)
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/ActorGalleryViewModel.kt
@@ -43,6 +43,11 @@ class ActorGalleryViewModel @Inject constructor(
         )
     }
 
+    fun onRetry(){
+        updateState { copy(error = null) }
+        loadImages(actorId)
+    }
+
     override fun onBackClick() {
         emitEffect(ActorGalleryEffectUiState.NavigationBack)
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksContract.kt
@@ -3,4 +3,5 @@ package com.london.presentation.feature.details.actordetails.topmoviespicks
 interface TopMoviesPicksContract {
     fun onSaveMovie(movieId: Int)
     fun onBack()
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
+import com.london.presentation.feature.base.ErrorState
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.utils.Listen
@@ -29,9 +30,9 @@ fun TopMoviesPicksScreen(
     BuildScreen(
         onBack = viewModel::onBack,
         isLoading = state.isLoading,
-        isError = state.errorState != null
+        isError = state.errorState is ErrorState.NoInternet,
+        onRetry = viewModel::onRetry,
     ) {
-
         TopMoviesPicksContent(
             state = state,
             contract = viewModel,

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
@@ -47,6 +47,10 @@ class TopMoviesPicksViewModel @Inject constructor(
         )
     }
 
+    fun onRetry(){
+        getActorMoviePicksData()
+    }
+
     override fun onSaveMovie(movieId: Int) {
         updateState { copy(isSaved = isSaved) }
         emitEffect(TopMoviesPicksEffect.NavigationToMovieDetails(movieId))

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
@@ -47,7 +47,7 @@ class TopMoviesPicksViewModel @Inject constructor(
         )
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         getActorMoviePicksData()
     }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
@@ -48,6 +48,7 @@ class TopMoviesPicksViewModel @Inject constructor(
     }
 
     override fun onRetry(){
+        updateState { copy(errorState = null) }
         getActorMoviePicksData()
     }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksContract.kt
@@ -4,4 +4,5 @@ interface TopTvShowsPicksContract {
     fun onSaveMovie(movieId: Int)
     fun onTvShowClicked(tvShowId: Int)
     fun onBack()
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
+import com.london.presentation.feature.base.ErrorState
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.utils.Listen
@@ -30,14 +31,13 @@ fun TopTvShowsPicksScreen(
     BuildScreen(
         onBack = viewModel::onBack,
         isLoading = state.isLoading,
-        isError = state.errorState != null
+        isError = state.errorState is ErrorState.NoInternet,
+        onRetry = viewModel::onRetry
     ) {
-
         TopTvShowsPicksContent(
             state = state,
             contract = viewModel,
         )
-
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
@@ -44,7 +44,7 @@ class TopTvShowsPicksViewModel @Inject constructor(
         )
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         updateState { copy(errorState = null) }
         getActorTvShowsPicksData()
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
@@ -44,6 +44,11 @@ class TopTvShowsPicksViewModel @Inject constructor(
         )
     }
 
+    fun onRetry(){
+        updateState { copy(errorState = null) }
+        getActorTvShowsPicksData()
+    }
+
     override fun onSaveMovie(movieId: Int) {
         updateState { copy(isSaved = !this.isSaved) }
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsContract.kt
@@ -8,4 +8,5 @@ interface MovieDetailsContract {
     fun onActorClick(actorId: Int)
     fun onReviewsClick(movieId: Int, mediaNumber: Int)
     fun onGenreClick(genreId: Int)
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -67,7 +67,6 @@ import com.london.presentation.R.string.overview
 import com.london.presentation.R.string.star
 import com.london.presentation.R.string.time_icon
 import com.london.presentation.R.string.view_reviews
-import com.london.presentation.feature.base.ErrorState
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.feature.reviews.MediaType
 import com.london.presentation.feature.search.SearchCategory
@@ -108,7 +107,7 @@ fun MovieDetailsScreen(
     BuildScreen(
         onBack = viewModel::onBackClick,
         isLoading = state.isLoading,
-        isError = state.error is ErrorState.NoInternet,
+        isError = state.error != null,
         onRetry = viewModel::onRetry
     ) {
         MovieDetailsContent(

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsScreen.kt
@@ -67,6 +67,7 @@ import com.london.presentation.R.string.overview
 import com.london.presentation.R.string.star
 import com.london.presentation.R.string.time_icon
 import com.london.presentation.R.string.view_reviews
+import com.london.presentation.feature.base.ErrorState
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.feature.reviews.MediaType
 import com.london.presentation.feature.search.SearchCategory
@@ -107,7 +108,8 @@ fun MovieDetailsScreen(
     BuildScreen(
         onBack = viewModel::onBackClick,
         isLoading = state.isLoading,
-        isError = state.error != null
+        isError = state.error is ErrorState.NoInternet,
+        onRetry = viewModel::onRetry
     ) {
         MovieDetailsContent(
             uiState = state,

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
@@ -124,6 +124,12 @@ class MovieDetailsViewModel @Inject constructor(
         addToRecentViewedUseCase.invoke(movie)
     }
 
+    fun onRetry() {
+        updateState { copy(error = null) }
+        loadMovieDetails(movieId)
+        loadSimilarAndVideos(movieId)
+    }
+
     private fun loadSimilarAndVideos(movieId: Int) {
         tryToExecute(
             block = {

--- a/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movieDetalis/MovieDetailsViewModel.kt
@@ -124,7 +124,7 @@ class MovieDetailsViewModel @Inject constructor(
         addToRecentViewedUseCase.invoke(movie)
     }
 
-    fun onRetry() {
+    override fun onRetry() {
         updateState { copy(error = null) }
         loadMovieDetails(movieId)
         loadSimilarAndVideos(movieId)

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsScreen.kt
@@ -80,7 +80,8 @@ fun EpisodeDetailsScreen(
     BuildScreen(
         onBack = viewModel::onBackClicked,
         isLoading = uiState.isLoading,
-        isError = uiState.error != null
+        isError = uiState.error != null,
+        onRetry = viewModel::onRetry
     ) {
         EpisodeDetailsScreenContent(
             uiState = uiState,

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episodedetails/EpisodeDetailsViewModel.kt
@@ -23,8 +23,8 @@ class EpisodeDetailsViewModel @Inject constructor(
 
     private val args = savedStateHandle.getArgs<Screen.EpisodeDetails>()
     val tvShowId = args?.tvShowId ?: 0
-    val seasonNumber = args?.seasonNumber ?: 0
-    val episodeNumber = args?.episodeNumber ?: 0
+    private val seasonNumber = args?.seasonNumber ?: 0
+    private val episodeNumber = args?.episodeNumber ?: 0
 
     init {
         loadEpisodeDetails()
@@ -84,6 +84,12 @@ class EpisodeDetailsViewModel @Inject constructor(
                 }
             }
         )
+    }
+
+    fun onRetry(){
+        updateState { copy(error = null) }
+        loadEpisodeDetails()
+        loadVideoProvider()
     }
 
     override fun onBackClicked() {

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsScreen.kt
@@ -115,7 +115,8 @@ fun TvShowsDetailsScreen(
     BuildScreen(
         onBack = viewModel::onBackClicked,
         isLoading = uiState.isLoading,
-        isError = uiState.error != null
+        isError = uiState.error != null,
+        onRetry = viewModel::onRetry
     ) {
         TvShowsDetailScreenContent(
             uiState = uiState,

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/TvShowDetailsViewModel.kt
@@ -187,14 +187,12 @@ class TvShowDetailsViewModel @Inject constructor(
         )
     }
 
-    fun onEpisodeClick(tvShowId: Int, episodeNumber: Int, seasonNumber: Int) {
-        emitEffect(
-            TvShowDetailsEffect.OnNavigateToEpisodeDetails(
-                tvShowId = tvShowId,
-                episodeNumber = episodeNumber,
-                seasonNumber = seasonNumber
-            )
-        )
+    fun onRetry() {
+        updateState { copy(error = null) }
+        initializeGetTvShowDetailsData()
+        initializeGetCastData()
+        initializeGetImagesData()
+        initializeEpisodesBySeasons()
     }
 
     override fun onEpisodeClicked(tvShowId: Int, episodeNumber: Int, seasonNumber: Int) {

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -107,8 +107,17 @@ fun HomeScreen(
     val screenWidth =
         with(LocalDensity.current) { LocalWindowInfo.current.containerSize.width.toDp() }
 
+    val upcomingMoviesLazyList = uiState.upcomingMovies.collectAsLazyPagingItems()
+
+
     when{
-        uiState.error != null -> NetworkErrorScreen(onBack = null)
+        uiState.error != null -> NetworkErrorScreen(
+            onRetry = {
+                viewModel.onRetry()
+                upcomingMoviesLazyList.retry()
+            },
+            onBack = null
+        )
 
         else ->
             Box(

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenContract.kt
@@ -11,6 +11,7 @@ interface HomeScreenContract {
     fun onTrendingTvShowsCardClicked()
     fun onTrendingActorsCardClicked()
     fun onMovieGenreSelect(genre: MovieGenre)
+    fun onRetry()
 }
 
 fun defaultHomeScreenContract() = object : HomeScreenContract {
@@ -22,4 +23,5 @@ fun defaultHomeScreenContract() = object : HomeScreenContract {
     override fun onTrendingTvShowsCardClicked() {}
     override fun onTrendingActorsCardClicked() {}
     override fun onMovieGenreSelect(genre: MovieGenre) {}
+    override fun onRetry() {}
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
@@ -114,7 +114,7 @@ class HomeViewModel @Inject constructor(
         )
     }
 
-    fun onRetry() {
+    override fun onRetry() {
         updateState { copy(error = null) }
         initializeTopRatedMedia()
         fetchRecentWatchedMedia()

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
@@ -114,6 +114,13 @@ class HomeViewModel @Inject constructor(
         )
     }
 
+    fun onRetry() {
+        updateState { copy(error = null) }
+        initializeTopRatedMedia()
+        fetchRecentWatchedMedia()
+        initializePopularMedia()
+    }
+
     override fun onMovieClick(id: Int) {
         emitEffect(HomeScreenEffect.NavigationMovieDetails(id))
     }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
@@ -15,14 +15,17 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.ActorItem
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.string
 import com.london.presentation.R
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.LazyPagingColumn
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.isLoading
 
 @Composable
 fun TrendingActorsScreen(
@@ -40,16 +43,29 @@ fun TrendingActorsScreen(
         }
     }
 
-    TrendingActorsContent(
-        state = state,
-        contract = viewModel
-    )
+
+    val actorsLazyItems = state.actorsFlow.collectAsLazyPagingItems()
+
+    BuildScreen(
+        isLoading = actorsLazyItems.isLoading(),
+        isError = actorsLazyItems.loadState.refresh is LoadState.Error,
+        onBack = viewModel::onBack,
+        onRetry = viewModel::onRetry,
+        emptyLayoutMessage = R.string.no_trending_actors_in_genre,
+        emptyLayoutImage = R.drawable.img_no_result,
+        pagingFlow = actorsLazyItems
+    ) {
+        TrendingActorsContent(
+            state = state,
+            contract = viewModel,
+        )
+    }
 }
 
 @Composable
 private fun TrendingActorsContent(
     state: TrendingActorsUiState = TrendingActorsUiState(),
-    contract: TrendingActorsContract = defaultTrendingActorsContract()
+    contract: TrendingActorsContract = defaultTrendingActorsContract(),
 ) {
     LazyColumn(
         modifier = Modifier
@@ -70,12 +86,10 @@ private fun TrendingActorsContent(
         }
 
         item {
-            val actorsLazyItems = state.actorsFlow.collectAsLazyPagingItems()
-
 
             LazyPagingColumn(
                 emptyTitle = R.string.no_trending_actors_in_genre.string,
-                pagingItems = actorsLazyItems,
+                pagingItems = state.actorsFlow.collectAsLazyPagingItems(),
                 modifier = Modifier.fillMaxSize(),
                 onRetry = {
                     contract.onRetry()

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
@@ -20,7 +20,6 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.ActorItem
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
-import com.london.designsystem.utils.string
 import com.london.presentation.R
 import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.LazyPagingColumn
@@ -88,12 +87,8 @@ private fun TrendingActorsContent(
         item {
 
             LazyPagingColumn(
-                emptyTitle = R.string.no_trending_actors_in_genre.string,
                 pagingItems = state.actorsFlow.collectAsLazyPagingItems(),
                 modifier = Modifier.fillMaxSize(),
-                onRetry = {
-                    contract.onRetry()
-                },
                 itemContent = { actor ->
                     ActorItem(
                         actorName = actor.name,

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesContract.kt
@@ -1,6 +1,5 @@
 package com.london.presentation.feature.home.trending.movies
 
-import androidx.paging.LoadState
 import com.london.presentation.utils.MovieGenre
 
 interface TrendingMoviesContract {
@@ -8,7 +7,6 @@ interface TrendingMoviesContract {
     fun onGenreSelected(genre: MovieGenre)
     fun onBack()
     fun onRetry()
-    fun onError(error: LoadState.Error)
 }
 
 fun defaultTrendingMoviesContract() = object : TrendingMoviesContract {
@@ -16,5 +14,4 @@ fun defaultTrendingMoviesContract() = object : TrendingMoviesContract {
     override fun onGenreSelected(genre: MovieGenre) {}
     override fun onBack() {}
     override fun onRetry() {}
-    override fun onError(error: LoadState.Error) {}
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesScreen.kt
@@ -46,7 +46,6 @@ fun TrendingMoviesScreen(
 
     val moviesLazyItems = state.moviesFlow.collectAsLazyPagingItems()
 
-
     BuildScreen(
         isLoading = moviesLazyItems.isLoading(),
         isError = moviesLazyItems.loadState.refresh is LoadState.Error,
@@ -103,7 +102,6 @@ private fun TrendingMoviesContent(
                 .padding(horizontal = 16.dp),
             onSaveClick = { /* TODO: Implement save functionality */ },
             isItemSaved = { false },
-            noMediaMessage = R.string.trending_movies,
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesScreen.kt
@@ -17,13 +17,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.GenresSection
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.isLoading
 
 @Composable
 fun TrendingMoviesScreen(
@@ -41,10 +44,23 @@ fun TrendingMoviesScreen(
         }
     }
 
-    TrendingMoviesContent(
-        state = state,
-        contract = viewModel
-    )
+    val moviesLazyItems = state.moviesFlow.collectAsLazyPagingItems()
+
+
+    BuildScreen(
+        isLoading = moviesLazyItems.isLoading(),
+        isError = moviesLazyItems.loadState.refresh is LoadState.Error,
+        onBack = viewModel::onBack,
+        onRetry = viewModel::onRetry,
+        emptyLayoutMessage = R.string.no_trending_movies_in_genre,
+        emptyLayoutImage = R.drawable.img_no_result,
+        pagingFlow = moviesLazyItems
+    ) {
+        TrendingMoviesContent(
+            state = state,
+            contract = viewModel
+        )
+    }
 }
 
 @Composable
@@ -53,7 +69,6 @@ private fun TrendingMoviesContent(
     contract: TrendingMoviesContract = defaultTrendingMoviesContract()
 ) {
     val screenWidth = with(LocalDensity.current) { LocalConfiguration.current.screenWidthDp.dp }
-    val moviesLazyItems = state.moviesFlow.collectAsLazyPagingItems()
 
     Column(
         modifier = Modifier
@@ -78,7 +93,7 @@ private fun TrendingMoviesContent(
             getGenreName = { stringResource(it.stringResId) }
         )
         MediaLazyPagingGrid(
-            pagingFlow = moviesLazyItems,
+            pagingFlow = state.moviesFlow.collectAsLazyPagingItems(),
             onItemClick = { contract.onMovieClick(it.id) },
             getImageUrl = { it.posterPath },
             getTitle = { it.title },
@@ -88,10 +103,7 @@ private fun TrendingMoviesContent(
                 .padding(horizontal = 16.dp),
             onSaveClick = { /* TODO: Implement save functionality */ },
             isItemSaved = { false },
-            onRetry = {
-                contract.onRetry()
-            },
-            noMediaMessage = R.string.no_trending_movies_in_genre
+            noMediaMessage = R.string.trending_movies,
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/movies/TrendingMoviesViewModel.kt
@@ -59,8 +59,4 @@ class TrendingMoviesViewModel @Inject constructor(
     override fun onRetry() {
         initializeMovies()
     }
-
-    override fun onError(error: androidx.paging.LoadState.Error) {
-        onRetry()
-    }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshows/TrendingTvShowsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshows/TrendingTvShowsScreen.kt
@@ -17,13 +17,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.shared.GenresSection
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.isLoading
 
 @Composable
 fun TrendingTvShowsScreen(
@@ -41,10 +44,22 @@ fun TrendingTvShowsScreen(
         }
     }
 
-    TrendingTvShowsContent(
-        state = state,
-        contract = viewModel,
-    )
+    val tvShowsLazyItems = state.tvShowsFlow.collectAsLazyPagingItems()
+
+    BuildScreen(
+        isLoading = tvShowsLazyItems.isLoading(),
+        isError = tvShowsLazyItems.loadState.refresh is LoadState.Error,
+        onBack = viewModel::onBack,
+        onRetry = viewModel::onRetry,
+        emptyLayoutMessage = R.string.no_trending_tvshows_in_genre,
+        emptyLayoutImage = R.drawable.img_no_result,
+        pagingFlow = tvShowsLazyItems
+    ) {
+        TrendingTvShowsContent(
+            state = state,
+            contract = viewModel,
+        )
+    }
 }
 
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshows/TrendingTvShowsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshows/TrendingTvShowsScreen.kt
@@ -104,10 +104,6 @@ private fun TrendingTvShowsContent(
                 .padding(horizontal = 16.dp),
             onSaveClick = { /* TODO: Implement save functionality */ },
             isItemSaved = { false },
-            onRetry = {
-                contract.onRetry()
-            },
-            noMediaMessage = R.string.no_trending_tvshows_in_genre
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewContract.kt
@@ -2,4 +2,5 @@ package com.london.presentation.feature.reviews
 
 interface ReviewContract {
     fun onBackClicked()
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.CircularLoading
 import com.london.designsystem.component.ImageView
@@ -50,6 +51,7 @@ import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.shared.ReviewsDate
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.isLoading
 import com.london.presentation.utils.reverseDateFormat
 
 @Composable
@@ -62,10 +64,13 @@ fun ReviewsScreen(
 
     effect?.Listen { onNavigateBack() }
 
+    val reviewsList = uiState.reviews.collectAsLazyPagingItems()
+
     BuildScreen(
-        isLoading = uiState.isLoading,
-        isError = uiState.error != null,
+        isLoading = reviewsList.isLoading(),
+        isError = reviewsList.loadState.refresh is LoadState.Error,
         onBack = onNavigateBack,
+        onRetry = viewModel::onRetry
     ) {
         ReviewsScreenContent(
             uiState = uiState,

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsViewModel.kt
@@ -50,6 +50,11 @@ class ReviewsViewModel @Inject constructor(
         )
     }
 
+    fun onRetry(){
+        updateState { copy(error = null) }
+        initializeReviews(mediaType, mediaId)
+    }
+
     override fun onBackClicked() {
         emitEffect(ReviewEffect.NavigateBack)
     }

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsViewModel.kt
@@ -50,7 +50,7 @@ class ReviewsViewModel @Inject constructor(
         )
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         updateState { copy(error = null) }
         initializeReviews(mediaType, mediaId)
     }

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchContract.kt
@@ -5,7 +5,7 @@ import com.london.domain.entity.recent.RecentSearch
 import com.london.domain.entity.recent.RecentViewed
 import com.london.presentation.feature.search.model.MovieUi
 
-interface SearchInteractions {
+interface SearchContract {
     fun onSearchQueryChange(newValue: TextFieldValue)
     fun onSearchFilterClick(query: String, category: SearchCategory)
     fun onCategorySelected(category: SearchCategory)
@@ -32,4 +32,5 @@ interface SearchInteractions {
     fun onTvShowClick(tvShowId: Int)
     fun onFilterClick()
     fun onFilterSheetDismiss()
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -50,7 +50,9 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.EmptyLayout
 import com.london.designsystem.component.HomeCard
@@ -68,6 +70,7 @@ import com.london.domain.entity.recent.RecentSearch
 import com.london.domain.entity.recent.RecentViewed
 import com.london.presentation.R
 import com.london.presentation.feature.base.ErrorState
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.shared.ActorsLayout
 import com.london.presentation.shared.FilterBottomSheet
@@ -80,7 +83,7 @@ import com.london.presentation.utils.ResultOrEmpty
 
 @Composable
 private fun HandleLoadStateError(
-    loadState: androidx.paging.CombinedLoadStates,
+    loadState: CombinedLoadStates,
     viewModel: SearchViewModel
 ) {
     LaunchedEffect(loadState) {
@@ -115,15 +118,30 @@ fun SearchScreen(
         }
     }
 
-    when {
-        state.error is ErrorState.NoInternet -> NetworkErrorScreen(onBack = null)
-        else ->
-            SearchScreenContent(
-                state = state,
-                interactionListener = viewModel,
-                keyboardController = keyboardController,
-                viewModel = viewModel,
-            )
+    val actorFlow = state.actorsFlow.collectAsLazyPagingItems()
+    val tvShowFlow = state.tvShowsFlow.collectAsLazyPagingItems()
+    val movieFlow = state.moviesFlow.collectAsLazyPagingItems()
+
+    val currentPagingFlow = when (state.selectedCategory) {
+        SearchCategory.Movies -> movieFlow
+        SearchCategory.TvShows -> tvShowFlow
+        SearchCategory.Actors -> actorFlow
+    }
+
+    BuildScreen(
+        isLoading = false,
+        isError = currentPagingFlow.loadState.refresh is LoadState.Error,
+        onBack = {},
+        onRetry = viewModel::onRetry,
+        pagingFlow = currentPagingFlow,
+        handlePagingLoadingAutomatically = false
+    ) {
+        SearchScreenContent(
+            state = state,
+            interactionListener = viewModel,
+            keyboardController = keyboardController,
+            viewModel = viewModel,
+        )
     }
 }
 
@@ -650,7 +668,7 @@ private fun NoSearchResultLayOut(
 
 @Composable
 private fun SearchContentWithErrorHandling(
-    lazyPagingItems: androidx.paging.compose.LazyPagingItems<*>,
+    lazyPagingItems: LazyPagingItems<*>,
     viewModel: SearchViewModel,
     state: SearchUiState,
     content: @Composable (Boolean) -> Unit

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -118,14 +118,10 @@ fun SearchScreen(
         }
     }
 
-    val actorFlow = state.actorsFlow.collectAsLazyPagingItems()
-    val tvShowFlow = state.tvShowsFlow.collectAsLazyPagingItems()
-    val movieFlow = state.moviesFlow.collectAsLazyPagingItems()
-
     val currentPagingFlow = when (state.selectedCategory) {
-        SearchCategory.Movies -> movieFlow
-        SearchCategory.TvShows -> tvShowFlow
-        SearchCategory.Actors -> actorFlow
+        SearchCategory.Movies -> state.moviesFlow.collectAsLazyPagingItems()
+        SearchCategory.TvShows -> state.tvShowsFlow.collectAsLazyPagingItems()
+        SearchCategory.Actors -> state.actorsFlow.collectAsLazyPagingItems()
     }
 
     BuildScreen(

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -148,7 +148,7 @@ fun SearchScreen(
 @Composable
 fun SearchScreenContent(
     state: SearchUiState,
-    interactionListener: SearchInteractions,
+    interactionListener: SearchContract,
     viewModel: SearchViewModel,
     keyboardController: SoftwareKeyboardController?,
 ) {
@@ -489,7 +489,7 @@ private fun SearchChipsRow(
 @Composable
 private fun RecentSearchLayOut(
     state: SearchUiState,
-    interactionListener: SearchInteractions,
+    interactionListener: SearchContract,
     viewModel: SearchViewModel,
     onNavigateToTvShowDetails: (Int) -> Unit,
     onNavigateToMovieDetails: (Int) -> Unit

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
@@ -528,4 +528,10 @@ class SearchViewModel @Inject constructor(
             )
         }
     }
+
+    fun onRetry(){
+        updateState { copy(error = null) }
+        updateRecentData()
+        setupSearchDebouncing()
+    }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
@@ -43,7 +43,7 @@ class SearchViewModel @Inject constructor(
     private val addToRecentViewedUseCase: AddToRecentViewedUseCase,
     private val clearRecentViewedUseCase: ClearRecentViewedUseCase,
     private val deleteRecentSearchUseCase: DeleteRecentSearchUseCase
-) : BaseViewModel<SearchUiState, SearchEffect>(SearchUiState()), SearchInteractions {
+) : BaseViewModel<SearchUiState, SearchEffect>(SearchUiState()), SearchContract {
 
     private val _searchQuery = MutableStateFlow("")
 
@@ -529,7 +529,7 @@ class SearchViewModel @Inject constructor(
         }
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         updateState { copy(error = null) }
         updateRecentData()
         setupSearchDebouncing()

--- a/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedContract.kt
@@ -10,4 +10,5 @@ interface TopRatedContract {
     fun onBackClicked()
     fun onMovieClick(id: Int)
     fun onTvShowClick(id: Int)
+    fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.R
 import com.london.designsystem.component.HomeCard
@@ -37,10 +38,12 @@ import com.london.designsystem.component.TabLayout
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.string
+import com.london.presentation.feature.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.MovieGenre
 import com.london.presentation.utils.TvShowGenre
 import com.london.presentation.utils.gridColmuns
+import com.london.presentation.utils.isLoading
 
 @Composable
 fun TopRatedScreen(
@@ -60,10 +63,21 @@ fun TopRatedScreen(
         }
     }
 
-    Content(
-        state = state,
-        topRatedContract = viewModel
-    )
+    val topRatedMovieFlow = state.movies.collectAsLazyPagingItems()
+    val topRatedTvShowFlow = state.tvSeries.collectAsLazyPagingItems()
+
+    BuildScreen(
+        isLoading = topRatedTvShowFlow.isLoading() && topRatedMovieFlow.isLoading(),
+        isError = topRatedMovieFlow.loadState.refresh is LoadState.Error
+                && topRatedTvShowFlow.loadState.refresh is LoadState.Error,
+        onBack = viewModel::onBackClicked,
+        onRetry = viewModel::onRetry,
+    ) {
+        Content(
+            state = state,
+            topRatedContract = viewModel
+        )
+    }
 }
 
 @Composable

--- a/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedViewModel.kt
@@ -67,7 +67,7 @@ class TopRatedViewModel @Inject constructor(
         }, checkSuccess = { true })
     }
 
-    fun onRetry(){
+    override fun onRetry(){
         updateState { copy(errorMessage = null) }
         initializeTopRated()
     }

--- a/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/toprated/TopRatedViewModel.kt
@@ -67,6 +67,11 @@ class TopRatedViewModel @Inject constructor(
         }, checkSuccess = { true })
     }
 
+    fun onRetry(){
+        updateState { copy(errorMessage = null) }
+        initializeTopRated()
+    }
+
     override fun movieGenre(genre: MovieGenre) {
         if (genre == state.value.selectedMovieGenre) return
         updateState { copy(selectedMovieGenre = genre) }

--- a/presentation/src/main/java/com/london/presentation/shared/FilterBottomSheet.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/FilterBottomSheet.kt
@@ -37,7 +37,7 @@ import com.london.designsystem.component.button.PrimaryButton
 import com.london.designsystem.component.rememberModalBottomSheetState
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
-import com.london.presentation.feature.search.SearchInteractions
+import com.london.presentation.feature.search.SearchContract
 import com.london.presentation.feature.search.SearchViewModel
 import kotlinx.coroutines.launch
 
@@ -52,7 +52,7 @@ data class FilterState(
 @Composable
 fun FilterBottomSheet(
     modifier: Modifier = Modifier,
-    filterInteractions: SearchInteractions,
+    filterInteractions: SearchContract,
     sheetState: SheetState = rememberModalBottomSheetState(),
     filterState: FilterState,
 ) {
@@ -113,7 +113,7 @@ fun FilterBottomSheet(
 @Composable
 private fun FilterBottomSheetContent(
     modifier: Modifier = Modifier,
-    filterInteractions: SearchInteractions,
+    filterInteractions: SearchContract,
     filterUiState: FilterState,
     onCloseClicked: () -> Unit,
     onApplyClicked: () -> Unit,

--- a/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
@@ -2,22 +2,11 @@ package com.london.presentation.shared
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
-import com.london.designsystem.component.CircularLoading
-import com.london.designsystem.component.EmptyLayout
-import com.london.presentation.R
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
-import com.london.presentation.utils.isEmpty
-import com.london.presentation.utils.isLoading
 
 @Composable
 fun <T : Any> LazyPagingColumn(
@@ -27,31 +16,12 @@ fun <T : Any> LazyPagingColumn(
     itemContent: @Composable (T) -> Unit,
     onRetry: () -> Unit = {}
 ) {
-    when {
-        pagingItems.loadState.refresh is LoadState.Error -> NetworkErrorScreen(
-            onRetry = onRetry, onBack = null
-        )
-
-        pagingItems.isLoading() -> CircularLoading(
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize(Alignment.Center)
-        )
-
-        pagingItems.isLoading().not() && pagingItems.isEmpty() -> EmptyLayout(
-            text = emptyTitle,
-            image = R.drawable.img_no_result,
-            modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding()
-        )
-
-        else -> Content(
+    Content(
             modifier = modifier,
             items = pagingItems,
             itemContent = itemContent
         )
-    }
+
 }
 
 @Composable

--- a/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/LazyPagingColumn.kt
@@ -10,18 +10,15 @@ import androidx.paging.compose.LazyPagingItems
 
 @Composable
 fun <T : Any> LazyPagingColumn(
-    emptyTitle: String,
     pagingItems: LazyPagingItems<T>,
     modifier: Modifier = Modifier,
     itemContent: @Composable (T) -> Unit,
-    onRetry: () -> Unit = {}
 ) {
     Content(
             modifier = modifier,
             items = pagingItems,
             itemContent = itemContent
         )
-
 }
 
 @Composable

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
@@ -1,6 +1,5 @@
 package com.london.presentation.shared
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,7 +12,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
 import com.london.designsystem.component.HomeCard
-import com.london.presentation.R
 import com.london.presentation.utils.gridColmuns
 
 @Composable
@@ -25,9 +23,6 @@ fun <T : Any> MediaLazyPagingGrid(
     modifier: Modifier = Modifier,
     onSaveClick: (T) -> Unit = {},
     isItemSaved: (T) -> Boolean = { false },
-    @StringRes noMediaMessage: Int,
-    emptyImage: Int = R.drawable.img_no_result,
-    onRetry: () -> Unit = {}
 ) {
     LazyVerticalGrid(
         state = rememberLazyGridState(),

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
@@ -5,25 +5,16 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
-import com.london.designsystem.component.CircularLoading
-import com.london.designsystem.component.EmptyLayout
 import com.london.designsystem.component.HomeCard
-import com.london.designsystem.utils.string
 import com.london.presentation.R
-import com.london.presentation.feature.buildscreen.NetworkErrorScreen
 import com.london.presentation.utils.gridColmuns
-import com.london.presentation.utils.isLoading
 
 @Composable
 fun <T : Any> MediaLazyPagingGrid(
@@ -38,46 +29,24 @@ fun <T : Any> MediaLazyPagingGrid(
     emptyImage: Int = R.drawable.img_no_result,
     onRetry: () -> Unit = {}
 ) {
-    when {
-        pagingFlow.loadState.refresh is LoadState.Error -> NetworkErrorScreen(
-            onRetry = onRetry, onBack = null
-        )
-
-        pagingFlow.isLoading() -> CircularLoading(
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize(Alignment.Center)
-        )
-
-        pagingFlow.isLoading().not() && pagingFlow.itemCount == 0 -> EmptyLayout(
-            text = noMediaMessage.string,
-            image = emptyImage,
-            modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding()
-        )
-
-        else -> {
-            LazyVerticalGrid(
-                state = rememberLazyGridState(),
-                columns = GridCells.Fixed(gridColmuns()),
-                modifier = modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(bottom = 16.dp)
-            ) {
-                items(pagingFlow.itemCount) { index ->
-                    val item = pagingFlow[index]
-                    if (item != null) {
-                        HomeCard(
-                            imageUrl = getImageUrl(item),
-                            onSaveClick = { onSaveClick(item) },
-                            isSaved = isItemSaved(item),
-                            imageDescription = getTitle(item),
-                            modifier = Modifier.clickable { onItemClick(item) }
-                        )
-                    }
-                }
+    LazyVerticalGrid(
+        state = rememberLazyGridState(),
+        columns = GridCells.Fixed(gridColmuns()),
+        modifier = modifier.fillMaxSize(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = PaddingValues(bottom = 16.dp)
+    ) {
+        items(pagingFlow.itemCount) { index ->
+            val item = pagingFlow[index]
+            if (item != null) {
+                HomeCard(
+                    imageUrl = getImageUrl(item),
+                    onSaveClick = { onSaveClick(item) },
+                    isSaved = isItemSaved(item),
+                    imageDescription = getTitle(item),
+                    modifier = Modifier.clickable { onItemClick(item) }
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/london/presentation/utils/Utils.kt
+++ b/presentation/src/main/java/com/london/presentation/utils/Utils.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.toSize
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
 import java.util.Locale
 
 fun Any?.toLocalizedNumbers(): String {
@@ -138,9 +140,21 @@ fun rememberContainerSize(): DpSize {
 }
 
 @Composable
-fun gridColmuns(): Int= runCatching {
+fun gridColmuns(): Int = runCatching {
     val screenWidth = LocalWindowInfo.current.containerSize.width
     val itemWidthPx = with(LocalDensity.current) { 158.dp.toPx() }
     val screenPaddingPx = with(LocalDensity.current) { 16.dp.toPx() }
     ((screenWidth - screenPaddingPx) / itemWidthPx).toInt().coerceAtLeast(2)
 }.getOrDefault(1)
+
+fun Int?.isNotNull(): Boolean {
+    return this != null
+}
+
+fun shouldShowLoading(
+    isLoading: Boolean,
+    handlePagingLoadingAutomatically: Boolean = true,
+    pagingFlow: LazyPagingItems<*>? = null
+): Boolean = isLoading || (handlePagingLoadingAutomatically
+        && pagingFlow?.loadState?.refresh is LoadState.Loading)
+


### PR DESCRIPTION
# What does this PR do?

This PR refactors multiple screens to use the `BuildScreen` composable for handling loading and error states. This provides a consistent user experience and simplifies the code in individual screens.

The `BuildScreen` now handles:
- Displaying a loading indicator.
- Displaying a network error screen with a retry option.
- Displaying an empty state message and image when paging data is empty.
- Retry functionality for failed data loading.

The following screens and ViewModels have been updated to utilize `BuildScreen` and its new capabilities:

- ActorDetailsScreen
- MovieDetailsScreen & MovieDetailsViewModel
- SearchScreen & SearchViewModel
- EpisodeDetailsScreen & EpisodeDetailsViewModel
- ActorGalleryScreen & ActorGalleryViewModel
- TopMoviesPicksScreen & TopMoviesPicksViewModel
- TopTvShowsPicksScreen & TopTvShowsPicksViewModel
- HomeScreen & HomeViewModel
- TrendingMoviesScreen & TrendingMoviesViewModel
- TrendingTvShowsScreen
- TopRatedScreen & TopRatedViewModel
- TvShowDetailsScreen & TvShowDetailsViewModel
- MoviesByCategoryScreen
- TvShowByCategoryScreen
- ReviewsScreen & ReviewsViewModel
- TrendingActorsScreen

Additionally:
- `LazyPagingColumn` and `MediaLazyPagingGrid` have been simplified by removing their internal loading/error/empty state handling, as this is now managed by `BuildScreen`.
- `TrendingMoviesContract`'s `onError` function was removed as error handling is now centralized.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
