### PR TITLE
Refactor: Remove duplicates from recent search results

### DIFF
--- a/domain/src/main/java/com/london/domain/usecase/recent/search/GetRecentSearchUseCase.kt
+++ b/domain/src/main/java/com/london/domain/usecase/recent/search/GetRecentSearchUseCase.kt
@@ -8,5 +8,5 @@ class GetRecentSearchUseCase @Inject constructor(
     private val recentSearchRepository: RecentRepository<RecentSearch>
 ) {
 
-    suspend fun invoke(): List<RecentSearch> = recentSearchRepository.getAll()
+    suspend fun invoke(): List<RecentSearch> = recentSearchRepository.getAll().distinct()
 }

--- a/domain/src/main/java/com/london/domain/usecase/recent/search/GetRecentSearchUseCase.kt
+++ b/domain/src/main/java/com/london/domain/usecase/recent/search/GetRecentSearchUseCase.kt
@@ -8,5 +8,5 @@ class GetRecentSearchUseCase @Inject constructor(
     private val recentSearchRepository: RecentRepository<RecentSearch>
 ) {
 
-    suspend fun invoke(): List<RecentSearch> = recentSearchRepository.getAll().distinct()
+    suspend fun invoke(): List<RecentSearch> = recentSearchRepository.getAll()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
@@ -141,6 +141,8 @@ class SearchViewModel @Inject constructor(
 
     override fun addToRecentSearches(query: RecentSearch) {
         if (query.query.isBlank() || query.query == state.value.lastSearch) return
+        if (isQueryDuplicated(query.query)) return
+
         updateState { copy(lastSearch = query.query) }
 
         tryToExecute(
@@ -156,6 +158,8 @@ class SearchViewModel @Inject constructor(
             },
         )
     }
+
+    private fun isQueryDuplicated(query: String) = query.equals(state.value.lastSearch, ignoreCase = true)
 
     override fun addToRecentViewed(item: RecentViewed) {
         tryToExecute(


### PR DESCRIPTION
# What does this PR do?

The `GetRecentSearchUseCase` now ensures that the list of recent searches returned by `invoke()` contains only unique items by calling `distinct()` on the result from the repository.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Domain

## Screenshots
<img width="471" height="831" alt="image" src="https://github.com/user-attachments/assets/3cb52fab-ab38-453c-a6bc-2f64090c75ba" />


## Checklist
- [x] Ready for review
