### PR TITLE
fix: Image scaling and pager dots visibility

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
@@ -149,7 +149,7 @@ fun ActorScreenContent(
                     uiState.actorImageDetails?.let { image ->
                         CustomBackDropImagePager(
                             images = image.map { it.fileUrl },
-                            isVisibleDots = false
+                            isVisibleDots = uiState.actorImageDetails.size > 1
                         )
                     }
                 }

--- a/presentation/src/main/java/com/london/presentation/shared/CustomBackDropImagePager.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/CustomBackDropImagePager.kt
@@ -83,7 +83,7 @@ fun CustomBackDropImagePager(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(252.dp),
-                    contentScale = ContentScale.FillBounds,
+                    contentScale = ContentScale.Crop,
                     model = validImages[pageIndex],
                     contentDescription = "${stringResource(R.string.tv_show_image)} ${pageIndex + 1}",
                     errorContent = { ErrorImage() },


### PR DESCRIPTION
# What does this PR do?
- Changed image scaling in `CustomBackDropImagePager` from `FillBounds` to `Crop` for better image display.
- Updated `ActorDetailsScreen` to only show pager dots when there is more than one image.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
