### PR TITLE
feat: Add javax.inject dependency and configure kapt

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -24,5 +24,9 @@ dependencies {
     testImplementation(libs.bundles.testing)
     implementation(libs.bundles.dagger.runtime)
     kapt(libs.bundles.dagger.kapt)
+    implementation(libs.javax.inject)
+}
 
+kapt {
+    correctErrorTypes = true
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ firebaseBom = "33.16.0"
 firebaseMlModeldownloader = "25.0.1"
 gson = "2.13.1"
 javaxInject = "1"
+javaxInjectVersion = "1"
 kotlin = "2.0.21"
 kotlinxCoroutinesTestVersion = "1.10.2"
 ksp = "2.0.21-1.0.27"
@@ -131,6 +132,7 @@ gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 #koin-ksp-compiler = { group = "io.insert-koin", name = "koin-ksp-compiler", version.ref = "koinKspCompiler" }
 
 # Coroutines & Date/Time
+javax-inject = { module = "javax.inject:javax.inject", version.ref = "javaxInjectVersion" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }


### PR DESCRIPTION
This PR introduces the `javax.inject` dependency to the `domain` module. It also configures `kapt` by setting `correctErrorTypes = true` in the `domain/build.gradle.kts` file.


This fixes this issue:

<img width="1838" height="831" alt="image" src="https://github.com/user-attachments/assets/279783dd-ca4d-40e0-8bc0-71d3f2358f60" />
