### PR TITLE
Refactor: Improve actor details UI and data mapping

### DIFF
--- a/data/src/main/java/com/london/data/mapper/search/ActorMapper.kt
+++ b/data/src/main/java/com/london/data/mapper/search/ActorMapper.kt
@@ -3,6 +3,7 @@
 package com.london.data.mapper.search
 
 import com.london.data.remote.model.search.searchactor.SearchActorRemote
+import com.london.data.utils.asImageUrlOrEmpty
 import com.london.data.utils.orZero
 import com.london.domain.KoverIgnore
 import com.london.domain.entity.Actor
@@ -10,6 +11,6 @@ import com.london.domain.entity.Actor
 fun SearchActorRemote.toEntity() = Actor(
     id = id.orZero(),
     name = name.orEmpty(),
-    profilePictureUrl = profilePath.orEmpty(),
+    profilePictureUrl = profilePath.asImageUrlOrEmpty(),
     characterName = originalName.orEmpty(),
 )

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/actorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/actorDetailsScreen.kt
@@ -67,8 +67,6 @@ import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.HomeCard
 import com.london.presentation.shared.ImageView
 import com.london.presentation.shared.buildscreen.BuildScreen
-import com.london.presentation.shared.HomeCard
-import com.london.presentation.shared.ImageView
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.toLocalizedNumbers
@@ -151,7 +149,7 @@ fun ActorScreenContent(
                     uiState.actorImageDetails?.let { image ->
                         CustomBackDropImagePager(
                             images = image.map { it.fileUrl },
-                            isVisibleDots = uiState.actorImageDetails.size > 1
+                            isVisibleDots = false
                         )
                     }
                 }


### PR DESCRIPTION
# What does this PR do?
when there is only one image or less.
- Utilized `asImageUrlOrEmpty()` in `ActorMapper.kt` for profile picture URL to handle potential null or empty values.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI
- [x] Domain


## Checklist
- [x] Ready for review
