### PR TITLE
feat: Implement get movie list name and remove movie from list use cases

### DIFF
--- a/data/src/main/java/com/london/data/remote/exception/NetworkException.kt
+++ b/data/src/main/java/com/london/data/remote/exception/NetworkException.kt
@@ -13,7 +13,7 @@ sealed class NetworkException(override val message: String?) : Exception(message
     data class TimeoutException(override val message: String?) : NetworkException(message)
     data class BadRequestException(override val message: String?) : NetworkException(message)
     data class ManyRequestException(override val message: String?) : NetworkException(message)
-    data class CantAddMovieToListException(override val message: String?) : NetworkException(message)
+    data class EntryNotFoundException(override val message: String?) : NetworkException(message)
     data class NoInternetException(
         override val message: String
     ) : NetworkException(message)

--- a/data/src/main/java/com/london/data/remote/service/list/CustomMovieListsApiService.kt
+++ b/data/src/main/java/com/london/data/remote/service/list/CustomMovieListsApiService.kt
@@ -42,7 +42,7 @@ interface CustomMovieListsApiService {
         @Body movieAdditionBody: ListMovieBody
     ): Response<CustomListResponse>
 
-    @GET("3/list/{list_id}/remove_item")
+    @POST("3/list/{list_id}/remove_item")
     suspend fun removeMovieFromList(
         @Path("list_id") listId: Int,
         @Query("session_id") sessionId: String?,

--- a/data/src/main/java/com/london/data/remote/source/base/BaseRemoteDataSource.kt
+++ b/data/src/main/java/com/london/data/remote/source/base/BaseRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.london.data.remote.source.base
 
 import com.london.data.remote.exception.NetworkException
-import com.london.data.remote.exception.NetworkException.CantAddMovieToListException
+import com.london.data.remote.exception.NetworkException.EntryNotFoundException
 import com.london.data.remote.exception.UnProcessableEntityException
 import com.london.data.remote.model.list.CustomListResponse
 import kotlinx.coroutines.delay
@@ -30,7 +30,7 @@ interface BaseRemoteDatasource {
                 "Request timed out. Please try again."
             )
         )
-    } catch (e: CantAddMovieToListException) {
+    } catch (e: EntryNotFoundException) {
         throw e
     } catch (e: Exception) {
         Result.failure(
@@ -76,7 +76,7 @@ interface BaseRemoteDatasource {
 
                 if (result.body() is CustomListResponse &&
                     (result.body() as CustomListResponse).statusCode == 21
-                ) throw result.toCantAddMovieToListException()
+                ) throw result.toEntryNotFoundException()
 
                 getOrEmptyResult(result = result, mapper = mapper).map {
                     it ?: throw NetworkException.EmptyResponseException(
@@ -161,8 +161,8 @@ interface BaseRemoteDatasource {
         message = errorBody()?.string()
     )
 
-    private fun <T> Response<T>.toCantAddMovieToListException() =
-        NetworkException.CantAddMovieToListException(
-            message = "Cant add movie to list"
+    private fun <T> Response<T>.toEntryNotFoundException() =
+        EntryNotFoundException(
+            message = "Entry not found"
         )
 }

--- a/data/src/main/java/com/london/data/remote/source/list/CustomMovieListsRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/london/data/remote/source/list/CustomMovieListsRemoteDataSourceImpl.kt
@@ -63,23 +63,17 @@ class CustomMovieListsRemoteDataSourceImpl @Inject constructor(
         listId: Int,
         movieId: Int,
         sessionId: String?
-    ): Result<CustomListResponse> {
-        return try {
-            callApiWithRetry(
-                apiCall = {
-                    customMovieListsApiService.addMovieToList(
-                        listId = listId,
-                        sessionId = sessionId,
-                        movieAdditionBody = ListMovieBody(mediaId = movieId)
-                    )
-                },
-                mapper = { it },
-                retryCount = 5
+    ): Result<CustomListResponse> = callApiWithRetry(
+        apiCall = {
+            customMovieListsApiService.addMovieToList(
+                listId = listId,
+                sessionId = sessionId,
+                movieAdditionBody = ListMovieBody(mediaId = movieId)
             )
-        } catch (e: Exception) {
-            Result.failure(e)
-        }
-    }
+        },
+        mapper = { it },
+        retryCount = 5
+    )
 
     override suspend fun removeMovieFromList(
         listId: Int,
@@ -93,8 +87,8 @@ class CustomMovieListsRemoteDataSourceImpl @Inject constructor(
                 movieDeletionBody = ListMovieBody(mediaId = movieId)
             )
         },
-        mapper = { it }
-    )
+        mapper = { it })
+
 
     override suspend fun getAllMovieLists(
         page: Int,

--- a/data/src/main/java/com/london/data/repository/list/CustomMovieListRepositoryImpl.kt
+++ b/data/src/main/java/com/london/data/repository/list/CustomMovieListRepositoryImpl.kt
@@ -31,6 +31,12 @@ class CustomMovieListRepositoryImpl @Inject constructor(
             languageCode = preferencesService.appLanguage.value.code
         ).isSuccess
 
+    override suspend fun getMovieListName(listId: UInt): String =
+        remoteDataSource.getDetails(
+            listId = listId.toInt(),
+            page = 1
+        ).getOrThrow().name.orEmpty()
+
     override suspend fun getMovieLists(pageNumber: Int): PagedFetchResponse<MovieList> {
         val response = remoteDataSource.getAllMovieLists(
             page = pageNumber,
@@ -46,13 +52,13 @@ class CustomMovieListRepositoryImpl @Inject constructor(
     }
 
     override suspend fun addMovieToList(listId: UInt, movieId: UInt): Boolean {
-         remoteDataSource.addMovieToList(
+        remoteDataSource.addMovieToList(
             listId = listId.toInt(),
             movieId = movieId.toInt(),
             sessionId = authPreferences.getSessionId()
         ).onFailure {
             return false
-         }
+        }
         return true
     }
 
@@ -71,5 +77,20 @@ class CustomMovieListRepositoryImpl @Inject constructor(
             totalPages = 1,
             totalItems = response.itemCount.orZero()
         )
+    }
+
+    override suspend fun removeMovieFromList(
+        listId: UInt,
+        movieId: UInt
+    ): Boolean {
+
+        remoteDataSource.removeMovieFromList(
+            listId = listId.toInt(),
+            movieId = movieId.toInt(),
+            sessionId = authPreferences.getSessionId()
+        ).onFailure {
+            return false
+        }
+        return true
     }
 }

--- a/data/src/test/java/com/london/data/repository/list/CustomMovieListRepositoryImplTest.kt
+++ b/data/src/test/java/com/london/data/repository/list/CustomMovieListRepositoryImplTest.kt
@@ -151,6 +151,32 @@ class CustomMovieListRepositoryImplTest {
     }
 
     @Test
+    fun `removeMovieFromList should return true when data source returns success`() = runTest {
+
+        //Given
+        coEvery { remoteDataSource.removeMovieFromList(any(), any(), any()) } returns Result.success(
+            CustomListResponse("", 1)
+        )
+        //When
+        val result = repository.removeMovieFromList(1u, 100u)
+        //Then
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `removeMovieFromList should return false when data source returns failure`() = runTest {
+
+        //Given
+        coEvery { remoteDataSource.addMovieToList(any(), any(), any()) } returns Result.failure(
+            Exception("error")
+        )
+        //When
+        val result = repository.addMovieToList(1u, 100u)
+        //Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
     fun `getMovieListDetails should return paged data when data source returns success`() = runTest {
 
         //Given
@@ -173,6 +199,30 @@ class CustomMovieListRepositoryImplTest {
         //When //Then
         assertThrows<NetworkException.HttpLockedException> {
             repository.getMovieListDetails(1u, 1)
+        }
+    }
+
+    @Test
+    fun `getMovieListName should return name when data source returns movie list details`()= runTest {
+        //Given
+        coEvery { remoteDataSource.getDetails(any(), any()) } returns Result.success(
+            MovieListDetailsMock
+        )
+        //When
+        val result = repository.getMovieListName(1u)
+        //Then
+        assertThat(result).isEqualTo(MovieListDetailsMock.name)
+    }
+
+    @Test
+    fun `getMovieListName should throw exception when data source returns failure`() = runTest {
+        //Given
+        coEvery { remoteDataSource.getDetails(any(), any()) } returns Result.failure(
+            NetworkException.HttpLockedException("locked")
+        )
+        //When //Then
+        assertThrows<NetworkException.HttpLockedException> {
+            repository.getMovieListName(1u)
         }
     }
 

--- a/domain/src/main/java/com/london/domain/repository/CustomMovieListRepository.kt
+++ b/domain/src/main/java/com/london/domain/repository/CustomMovieListRepository.kt
@@ -8,7 +8,9 @@ interface CustomMovieListRepository {
 
     suspend fun deleteMovieList(id: UInt): Boolean
     suspend fun createMovieList(name: String): Boolean
-    suspend fun getMovieLists(pageNumber: Int): PagedFetchResponse<MovieList>
+    suspend fun getMovieListName(listId: UInt): String
     suspend fun addMovieToList(listId: UInt, movieId: UInt): Boolean
+    suspend fun removeMovieFromList(listId: UInt, movieId: UInt): Boolean
+    suspend fun getMovieLists(pageNumber: Int): PagedFetchResponse<MovieList>
     suspend fun getMovieListDetails(listId: UInt, pageNumber: Int): PagedFetchResponse<Movie>
 }

--- a/domain/src/main/java/com/london/domain/usecase/movielist/GetMovieListNameUseCase.kt
+++ b/domain/src/main/java/com/london/domain/usecase/movielist/GetMovieListNameUseCase.kt
@@ -1,0 +1,12 @@
+package com.london.domain.usecase.movielist
+
+import com.london.domain.repository.CustomMovieListRepository
+import javax.inject.Inject
+
+class GetMovieListNameUseCase @Inject constructor(
+    private val customMovieListRepository: CustomMovieListRepository,
+) {
+
+    suspend fun invoke(listId: UInt): String =
+        customMovieListRepository.getMovieListName(listId)
+}

--- a/domain/src/main/java/com/london/domain/usecase/movielist/RemoveMovieFromListUseCase.kt
+++ b/domain/src/main/java/com/london/domain/usecase/movielist/RemoveMovieFromListUseCase.kt
@@ -1,0 +1,12 @@
+package com.london.domain.usecase.movielist
+
+import com.london.domain.repository.CustomMovieListRepository
+import javax.inject.Inject
+
+class RemoveMovieFromListUseCase @Inject constructor(
+    private val customMovieListRepository: CustomMovieListRepository,
+) {
+
+    suspend fun invoke(listId: UInt, movieId: UInt): Boolean =
+        customMovieListRepository.removeMovieFromList(listId, movieId)
+}

--- a/domain/src/test/kotlin/com/london/domain/usecase/movielist/GetMovieListNameUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/london/domain/usecase/movielist/GetMovieListNameUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.london.domain.usecase.movielist
+
+import com.google.common.truth.Truth.assertThat
+import com.london.domain.repository.CustomMovieListRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+
+class GetMovieListNameUseCaseTest {
+
+    private lateinit var getMovieListNameUseCase: GetMovieListNameUseCase
+    private lateinit var customMovieListRepository: CustomMovieListRepository
+
+    @Before
+    fun setUp() {
+        customMovieListRepository = mockk()
+        getMovieListNameUseCase = GetMovieListNameUseCase(customMovieListRepository)
+    }
+
+    @Test
+    fun `invoke should return movie list name when repository returns name`() = runTest {
+        // Given
+        val listId = 1u
+        val expectedName = "Movie List Name"
+        coEvery { customMovieListRepository.getMovieListName(listId) } returns expectedName
+        // When
+        val result = getMovieListNameUseCase.invoke(listId)
+        // Then
+        assertThat(result).isEqualTo(expectedName)
+    }
+
+    @Test
+    fun `invoke should throw exception when repository throws exception`() = runTest {
+        // Given
+        val listId = 1u
+        coEvery { customMovieListRepository.getMovieListName(listId) } throws Exception()
+        // When // Then
+        assertThrows<Exception> {
+            getMovieListNameUseCase.invoke(listId)
+
+        }
+    }
+}

--- a/domain/src/test/kotlin/com/london/domain/usecase/movielist/RemoveMovieFromListUseCaseTest.kt
+++ b/domain/src/test/kotlin/com/london/domain/usecase/movielist/RemoveMovieFromListUseCaseTest.kt
@@ -1,0 +1,65 @@
+package com.london.domain.usecase.movielist
+
+import com.google.common.truth.Truth.assertThat
+import com.london.domain.repository.CustomMovieListRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertThrows
+
+class RemoveMovieFromListUseCaseTest {
+    private lateinit var customMovieListRepository: CustomMovieListRepository
+    private lateinit var removeMovieFromListUseCase: RemoveMovieFromListUseCase
+
+    @Before
+    fun setUp() {
+        customMovieListRepository = mockk()
+        removeMovieFromListUseCase = RemoveMovieFromListUseCase(customMovieListRepository)
+    }
+
+    @Test
+    fun `invoke should return true when removeMovieFromList on repository returns true`() =
+        runTest {
+            //Given
+            coEvery { customMovieListRepository.removeMovieFromList(any(), any()) } returns true
+            //When
+            val result = removeMovieFromListUseCase.invoke(LIST_ID, MOVIE_ID)
+            //Then
+            assertThat(result).isTrue()
+        }
+
+    @Test
+    fun `invoke should return false when removeMovieFromList on repository returns false`() =
+        runTest {
+            //Given
+            coEvery { customMovieListRepository.removeMovieFromList(any(), any()) } returns false
+            //When
+            val result = removeMovieFromListUseCase.invoke(LIST_ID, MOVIE_ID)
+            //Then
+            assertThat(result).isFalse()
+        }
+
+    @Test
+    fun `invoke should throw exception when removeMovieFromList on repository throws exception`() =
+        runTest {
+            //Given
+            coEvery {
+                customMovieListRepository.removeMovieFromList(
+                    any(),
+                    any()
+                )
+            } throws Exception()
+            //When //Then
+            assertThrows<Exception> {
+                removeMovieFromListUseCase.invoke(LIST_ID, MOVIE_ID)
+            }
+        }
+
+
+    private companion object {
+        const val LIST_ID = 10u
+        const val MOVIE_ID = 20u
+    }
+}


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
- `GetMovieListNameUseCase`: Retrieves the name of a specific movie list.
- `RemoveMovieFromListUseCase`: Removes a movie from a specific list.
- Corresponding repository methods and data source implementations.
- Updated API service for removing movies from lists (changed from GET to POST).
- Renamed `CantAddMovieToListException` to `EntryNotFoundException` for broader applicability.
- Unit tests for the new use cases and repository methods.
- Minor refactoring in `CustomMovieListsRemoteDataSourceImpl`.
## Type of Change
- [x] ✨ New feature

## Changes Made
- [x] Data
- [x] Domain

## Testing
- [x] Unit tests added/updated

