### PR TITLE
refactor: simplify theme handling by using Boolean for dark mode

### DIFF
--- a/app/src/main/java/com/london/app/MainActivity.kt
+++ b/app/src/main/java/com/london/app/MainActivity.kt
@@ -5,15 +5,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.view.WindowCompat
 import com.london.app.navigation.NovixApp
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.AppPreferencesService
-import com.london.domain.theme.AppTheme
-import com.london.domain.theme.isDark
 import com.london.presentation.shared.ContentRestrictionProvider
 import com.london.presentation.shared.LocalContentRestrictionLevel
 import dagger.hilt.android.AndroidEntryPoint
@@ -34,9 +32,9 @@ class MainActivity : ComponentActivity() {
         }
 
         setContent {
-            val appTheme by appPreferencesService.appTheme.collectAsState()
+            val isAppDarkMode by appPreferencesService.isAppDarkMode.collectAsState()
             NovixTheme(
-                isDarkMode = if (appTheme == AppTheme.SYSTEM) true else appTheme.name.isDark()
+                isAppDarkMode = isAppDarkMode
             ) {
                 ContentRestrictionProvider(appPreferencesService) { contentRestrictionLevel ->
                     CompositionLocalProvider(

--- a/data/src/main/java/com/london/data/local/preference/AppPreferencesServiceImpl.kt
+++ b/data/src/main/java/com/london/data/local/preference/AppPreferencesServiceImpl.kt
@@ -3,12 +3,11 @@ package com.london.data.local.preference
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.london.domain.AppPreferencesService
+import com.london.domain.contentrestriction.ContentRestrictionLevel
 import com.london.domain.language.AppLanguage
 import com.london.domain.theme.AppTheme
-import com.london.domain.theme.toAppTheme
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import com.london.domain.contentrestriction.ContentRestrictionLevel
 import javax.inject.Inject
 
 class AppPreferencesServiceImpl @Inject constructor(
@@ -24,18 +23,18 @@ class AppPreferencesServiceImpl @Inject constructor(
     //endregion
 
     //region App Theme
-    private val _appTheme = MutableStateFlow(getAppTheme())
-    override val appTheme: StateFlow<AppTheme> = _appTheme
+    private val _isAppDarkMode = MutableStateFlow(getAppTheme())
+    override val isAppDarkMode: StateFlow<Boolean> = _isAppDarkMode
 
-    private fun getAppTheme(): AppTheme {
+    private fun getAppTheme(): Boolean {
         val theme = preferences.getString(
-            PreferencesKeys.THEME_KEY, AppTheme.SYSTEM.name
-        ) ?: AppTheme.SYSTEM.name
-        return theme.toAppTheme()
+            PreferencesKeys.THEME_KEY, AppTheme.DARK.name
+        ) ?: AppTheme.DARK.name
+        return theme == AppTheme.DARK.name
     }
 
     override fun setAppTheme(theme: AppTheme) {
-        _appTheme.value = theme.name.toAppTheme()
+        _isAppDarkMode.value = theme == AppTheme.DARK
         preferences.edit { putString(PreferencesKeys.THEME_KEY, theme.name) }
     }
     //endregion

--- a/data/src/test/java/com/london/data/local/preference/AppPreferencesServiceImplTest.kt
+++ b/data/src/test/java/com/london/data/local/preference/AppPreferencesServiceImplTest.kt
@@ -74,7 +74,7 @@ class AppPreferencesServiceImplTest {
 
         // When
         service = AppPreferencesServiceImpl(sharedPreferences)
-        val currentTheme = service.appTheme.first()
+        val currentTheme = service.isAppDarkMode.first()
 
         // Then
         assertEquals(AppTheme.SYSTEM, currentTheme)
@@ -87,7 +87,7 @@ class AppPreferencesServiceImplTest {
 
         // When
         service = AppPreferencesServiceImpl(sharedPreferences)
-        val currentTheme = service.appTheme.first()
+        val currentTheme = service.isAppDarkMode.first()
 
         // Then
         assertEquals(AppTheme.DARK, currentTheme)

--- a/data/src/test/java/com/london/data/local/preference/AppPreferencesServiceImplTest.kt
+++ b/data/src/test/java/com/london/data/local/preference/AppPreferencesServiceImplTest.kt
@@ -48,8 +48,8 @@ class AppPreferencesServiceImplTest {
         every { sharedPreferences.edit() } returns editor
 
         every {
-            sharedPreferences.getString(THEME_KEY, AppTheme.SYSTEM.name)
-        } returns AppTheme.SYSTEM.name
+            sharedPreferences.getString(THEME_KEY, AppTheme.DARK.name)
+        } returns AppTheme.DARK.name
 
         every {
             sharedPreferences.getString(LANGUAGE_KEY, AppLanguage.ENGLISH.code)
@@ -68,30 +68,30 @@ class AppPreferencesServiceImplTest {
     }
 
     @Test
-    fun `appTheme returns default SYSTEM when no preference is set`() = runTest {
+    fun `appTheme returns default Dark theme true when no preference is set`() = runTest {
         // Given
-        every { sharedPreferences.getString(THEME_KEY, AppTheme.SYSTEM.name) } returns null
+        every { sharedPreferences.getString(THEME_KEY, AppTheme.DARK.name) } returns null
 
         // When
         service = AppPreferencesServiceImpl(sharedPreferences)
         val currentTheme = service.isAppDarkMode.first()
 
         // Then
-        assertEquals(AppTheme.SYSTEM, currentTheme)
+        assertEquals(true, currentTheme)
     }
 
     @Test
     fun `appTheme returns specific theme when preference is set`() = runTest {
         // Given
-        every { sharedPreferences.getString(THEME_KEY, AppTheme.SYSTEM.name) } returns AppTheme.DARK.name
+        every { sharedPreferences.getString(THEME_KEY, AppTheme.DARK.name) } returns AppTheme.DARK.name
 
         // When
         service = AppPreferencesServiceImpl(sharedPreferences)
         val currentTheme = service.isAppDarkMode.first()
 
         // Then
-        assertEquals(AppTheme.DARK, currentTheme)
-        verify { sharedPreferences.getString(THEME_KEY, AppTheme.SYSTEM.name) }
+        assertEquals(true, currentTheme)
+        verify { sharedPreferences.getString(THEME_KEY, AppTheme.DARK.name) }
     }
 
     @Test

--- a/designSystem/src/main/java/com/london/designsystem/theme/NovixTheme.kt
+++ b/designSystem/src/main/java/com/london/designsystem/theme/NovixTheme.kt
@@ -1,6 +1,5 @@
 package com.london.designsystem.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import com.london.designsystem.color.DarkNovixColors
@@ -9,15 +8,15 @@ import com.london.designsystem.typography.NovixTypography
 
 @Composable
 fun NovixTheme(
-    isDarkMode: Boolean = isSystemInDarkTheme(),
+    isAppDarkMode: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colors = if (isDarkMode) DarkNovixColors else LightNovixColors
+    val colors = if (isAppDarkMode) DarkNovixColors else LightNovixColors
 
     CompositionLocalProvider(
         LocalNovixColors provides colors,
         LocalNovixTypography provides NovixTypography,
-        LocalAppTheme provides if (isDarkMode) AppTheme.DARK else AppTheme.LIGHT
+        LocalAppTheme provides isAppDarkMode
     ) {
         content()
     }

--- a/designSystem/src/main/java/com/london/designsystem/theme/Theme.kt
+++ b/designSystem/src/main/java/com/london/designsystem/theme/Theme.kt
@@ -15,21 +15,6 @@ import com.london.designsystem.color.NovixColors
 import com.london.designsystem.typography.NovixTypography
 import com.london.designsystem.typography.NovixTypographySet
 
-enum class AppTheme {
-    LIGHT,
-    DARK;
-
-    fun isDark(): Boolean = this == DARK
-
-    companion object {
-        fun fromString(value: String): AppTheme = when (value) {
-            DARK.name -> DARK
-            else -> LIGHT
-        }
-    }
-}
-
-
 object NovixTheme {
     val colors: NovixColors
         @Composable @ReadOnlyComposable get() = LocalNovixColors.current
@@ -37,7 +22,7 @@ object NovixTheme {
     val typography: NovixTypographySet
         @Composable @ReadOnlyComposable get() = LocalNovixTypography.current
 
-    val theme: AppTheme
+    val isThemeDark: Boolean
         @Composable @ReadOnlyComposable get() = LocalAppTheme.current
 }
 
@@ -54,7 +39,7 @@ fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier = composed {
 val LocalNovixColors = staticCompositionLocalOf { LightNovixColors }
 val LocalNovixTypography = staticCompositionLocalOf { NovixTypography }
 
-val LocalAppTheme = staticCompositionLocalOf { AppTheme.DARK }
+val LocalAppTheme = staticCompositionLocalOf { true }
 
 val horizontalGradient = listOf(
     LinearGradientLight.copy(alpha = 1f),

--- a/domain/src/main/java/com/london/domain/AppPreferencesService.kt
+++ b/domain/src/main/java/com/london/domain/AppPreferencesService.kt
@@ -1,9 +1,9 @@
 package com.london.domain
 
+import com.london.domain.contentrestriction.ContentRestrictionLevel
 import com.london.domain.language.AppLanguage
 import com.london.domain.theme.AppTheme
 import kotlinx.coroutines.flow.StateFlow
-import com.london.domain.contentrestriction.ContentRestrictionLevel
 
 interface AppPreferencesService {
     //region Onboarding
@@ -11,7 +11,7 @@ interface AppPreferencesService {
     fun setOnBoardingShown()
     //endregion
     //region Theme
-    val appTheme: StateFlow<AppTheme>
+    val isAppDarkMode: StateFlow<Boolean>
     fun setAppTheme(theme: AppTheme)
     //endregion
     //region Language

--- a/domain/src/main/java/com/london/domain/theme/AppTheme.kt
+++ b/domain/src/main/java/com/london/domain/theme/AppTheme.kt
@@ -2,17 +2,5 @@ package com.london.domain.theme
 
 enum class AppTheme {
     LIGHT,
-    DARK,
-    SYSTEM
-}
-
-fun String.isDark(): Boolean = when (this) {
-    AppTheme.DARK.name -> true
-    else -> false
-}
-
-fun String.toAppTheme(): AppTheme = when (this) {
-    AppTheme.DARK.name -> AppTheme.DARK
-    AppTheme.LIGHT.name -> AppTheme.LIGHT
-    else -> AppTheme.SYSTEM
+    DARK
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -184,7 +184,11 @@ private fun Content(
                         .fillMaxSize()
                 ) {
                     DefaultTopBar(
-                        appIconRes = if (NovixTheme.theme.isDark()) R.drawable.img_novix_dark else R.drawable.img_novix_light,
+                        appIconRes = if (NovixTheme.isThemeDark) {
+                            R.drawable.img_novix_dark
+                        } else {
+                            R.drawable.img_novix_light
+                        },
                         appName = R.string.app_name.string,
                         appDescription = R.string.app_name_description.string,
                         appIconContentDescription = R.string.novix_icon.string,


### PR DESCRIPTION
# 📌 What does this PR do?
<!-- Briefly describe the purpose of this pull request and the context behind the changes -->
Simplified AppTheme handling and removed repeated logic related to dark mode.

---

## 🔧 Type of Change
<!-- Select the type of change by checking the box -->
- [x] 🔧 Refactoring (no functional changes)  

---

## 📂 Areas Affected
<!-- Tick all the modules/components that are affected -->

- [x] 🖼️ Compose UI  
- [x] 🗃️ Data  
- [x] 📦 Domain  

---

## ✅ Changes Made
<!-- Bullet points of what was changed or added -->
- Removed redundant theme-related code
- Centralized theme conversion logic
- Replaced manual string comparisons with enum-safe code
- Simplified `getAppTheme()` implementation

---

## 🧪 Testing
<!-- How was this tested? -->

- [x] Tested locally  
- [x] Unit tests added/updated  

---


## 📝 Checklist
<!-- Final checklist before marking PR as ready -->
- [x] Code builds without warnings or errors  
- [x] Self-reviewed the code  
- [x] All relevant tests pass  
- [x] Ready for review 🚀
