### PR TITLE
Refactor: Enhance Top Picks screen navigation and interactions

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksContract.kt
@@ -2,6 +2,7 @@ package com.london.presentation.feature.details.actordetails.topmoviespicks
 
 interface TopMoviesPicksContract {
     fun onSaveMovie(movieId: Int)
+    fun onMovieClicked(movieId: Int)
     fun onBack()
     fun onRetry()
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.feature.details.actordetails.toptvshowspicks
+package com.london.presentation.feature.details.actordetails.topmoviespicks
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -14,59 +14,60 @@ import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 
 @Composable
-fun TopTvShowsPicksScreen(
-    onNavigateTvShow: (tvShowId: Int) -> Unit,
+fun TopMoviesPicksScreen(
+    onNavigateMovie: (Int) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: TopTvShowsPicksViewModel = hiltViewModel(),
+    viewModel: TopMoviesPicksViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val effect by viewModel.effect.collectAsState(initial = null)
+    val effect by viewModel.effect.collectAsState(null)
 
-    HandleTvShowsPicksEffects(
+    HandleTopMoviesPicksEffects(
         effect = effect,
-        onNavigateTvShow = onNavigateTvShow,
+        onNavigateMovie = onNavigateMovie,
         onNavigateBack = onNavigateBack
     )
 
-    TopTvShowsPicksContent(
+    TopMoviesPicksContent(
         state = state,
         contract = viewModel,
     )
+
 }
 
 @Composable
-private fun TopTvShowsPicksContent(
-    state: TopTvShowsPicksUiState,
-    contract: TopTvShowsPicksContract,
+private fun TopMoviesPicksContent(
+    state: TopMoviesPicksUiState,
+    contract: TopMoviesPicksContract,
     modifier: Modifier = Modifier,
 ) {
     BuildScreen(
         onBack = contract::onBack,
         isLoading = state.isLoading,
         isError = state.errorState is ErrorState.NoInternet,
-        onRetry = contract::onRetry
+        onRetry = contract::onRetry,
     ) {
         MediaLazyGrid(
-            title = stringResource(R.string.top_tv_shows_picks),
-            items = state.tvShowDetails.cast,
+            title = stringResource(R.string.top_movies_picks),
+            items = state.movieDetails.cast,
             onBack = contract::onBack,
             getImageUrl = { it.posterUrl },
-            onSaveClick = { contract.onSaveMovie(it.id) },
+            onItemClick = { contract.onMovieClicked(it.id) },
             modifier = modifier
         )
     }
 }
 
 @Composable
-private fun HandleTvShowsPicksEffects(
-    effect: TopTvShowsPicksEffect?,
-    onNavigateTvShow: (Int) -> Unit,
-    onNavigateBack: () -> Unit
+private fun HandleTopMoviesPicksEffects(
+    effect: TopMoviesPicksEffect?,
+    onNavigateMovie: (Int) -> Unit,
+    onNavigateBack: () -> Unit,
 ) {
     effect?.Listen { currentEffect ->
         when (currentEffect) {
-            is TopTvShowsPicksEffect.TvShowNavigation -> onNavigateTvShow(currentEffect.tvShowId)
-            is TopTvShowsPicksEffect.BackNavigation -> onNavigateBack()
+            is TopMoviesPicksEffect.NavigateBack -> onNavigateBack()
+            is TopMoviesPicksEffect.NavigationToMovieDetails -> onNavigateMovie(currentEffect.movieId)
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksScreen.kt
@@ -53,6 +53,7 @@ private fun TopMoviesPicksContent(
             onBack = contract::onBack,
             getImageUrl = { it.posterUrl },
             onItemClick = { contract.onMovieClicked(it.id) },
+            onSavedClick = { contract.onSaveMovie(it.id) },
             modifier = modifier
         )
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/topmoviespicks/TopMoviesPicksViewModel.kt
@@ -54,6 +54,9 @@ class TopMoviesPicksViewModel @Inject constructor(
 
     override fun onSaveMovie(movieId: Int) {
         updateState { copy(isSaved = isSaved) }
+    }
+
+    override fun onMovieClicked(movieId: Int) {
         emitEffect(TopMoviesPicksEffect.NavigationToMovieDetails(movieId))
     }
 

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksContract.kt
@@ -1,7 +1,7 @@
 package com.london.presentation.feature.details.actordetails.toptvshowspicks
 
 interface TopTvShowsPicksContract {
-    fun onSaveMovie(movieId: Int)
+    fun onSaveTvShow(tvShowId: Int)
     fun onTvShowClicked(tvShowId: Int)
     fun onBack()
     fun onRetry()

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
@@ -52,6 +52,7 @@ private fun TopTvShowsPicksContent(
             onBack = contract::onBack,
             getImageUrl = { it.posterUrl },
             onItemClick = { contract.onTvShowClicked(it.id) },
+            onSavedClick = { contract.onSaveTvShow(it.id) },
             modifier = modifier
         )
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksScreen.kt
@@ -1,4 +1,4 @@
-package com.london.presentation.feature.details.actordetails.topmoviespicks
+package com.london.presentation.feature.details.actordetails.toptvshowspicks
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -14,60 +14,59 @@ import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 
 @Composable
-fun TopMoviesPicksScreen(
-    onNavigateMovie: (Int) -> Unit,
+fun TopTvShowsPicksScreen(
+    onNavigateTvShow: (Int) -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: TopMoviesPicksViewModel = hiltViewModel()
+    viewModel: TopTvShowsPicksViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
-    val effect by viewModel.effect.collectAsState(null)
+    val effect by viewModel.effect.collectAsState(initial = null)
 
-    HandleTopMoviesPicksEffects(
+    HandleTvShowsPicksEffects(
         effect = effect,
-        onNavigateMovie = onNavigateMovie,
+        onNavigateTvShow = onNavigateTvShow,
         onNavigateBack = onNavigateBack
     )
 
-    TopMoviesPicksContent(
+    TopTvShowsPicksContent(
         state = state,
         contract = viewModel,
     )
-
 }
 
 @Composable
-private fun TopMoviesPicksContent(
-    state: TopMoviesPicksUiState,
-    contract: TopMoviesPicksContract,
+private fun TopTvShowsPicksContent(
+    state: TopTvShowsPicksUiState,
+    contract: TopTvShowsPicksContract,
     modifier: Modifier = Modifier,
 ) {
     BuildScreen(
         onBack = contract::onBack,
         isLoading = state.isLoading,
         isError = state.errorState is ErrorState.NoInternet,
-        onRetry = contract::onRetry,
+        onRetry = contract::onRetry
     ) {
         MediaLazyGrid(
-            title = stringResource(R.string.top_movies_picks),
-            items = state.movieDetails.cast,
+            title = stringResource(R.string.top_tv_shows_picks),
+            items = state.tvShowDetails.cast,
             onBack = contract::onBack,
             getImageUrl = { it.posterUrl },
-            onSaveClick = { contract.onSaveMovie(it.id) },
+            onItemClick = { contract.onTvShowClicked(it.id) },
             modifier = modifier
         )
     }
 }
 
 @Composable
-private fun HandleTopMoviesPicksEffects(
-    effect: TopMoviesPicksEffect?,
-    onNavigateMovie: (Int) -> Unit,
-    onNavigateBack: () -> Unit,
+private fun HandleTvShowsPicksEffects(
+    effect: TopTvShowsPicksEffect?,
+    onNavigateTvShow: (Int) -> Unit,
+    onNavigateBack: () -> Unit
 ) {
     effect?.Listen { currentEffect ->
         when (currentEffect) {
-            is TopMoviesPicksEffect.NavigateBack -> onNavigateBack()
-            is TopMoviesPicksEffect.NavigationToMovieDetails -> onNavigateMovie(currentEffect.movieId)
+            is TopTvShowsPicksEffect.TvShowNavigation -> onNavigateTvShow(currentEffect.tvShowId)
+            is TopTvShowsPicksEffect.BackNavigation -> onNavigateBack()
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/toptvshowspicks/TopTvShowsPicksViewModel.kt
@@ -49,7 +49,7 @@ class TopTvShowsPicksViewModel @Inject constructor(
         getActorTvShowsPicksData()
     }
 
-    override fun onSaveMovie(movieId: Int) {
+    override fun onSaveTvShow(tvShowId: Int) {
         updateState { copy(isSaved = !this.isSaved) }
     }
 

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
@@ -31,7 +31,7 @@ fun <T> MediaLazyGrid(
     onBack: () -> Unit,
     getImageUrl: (T) -> String,
     modifier: Modifier = Modifier,
-    onSaveClick: (T) -> Unit = {},
+    onItemClick: (T) -> Unit = {},
     isItemSaved: (T) -> Boolean = { false },
     isLoading: Boolean = false,
     emptyTitle: String = "",
@@ -46,7 +46,7 @@ fun <T> MediaLazyGrid(
             modifier = Modifier
                 .fillMaxWidth()
                 .statusBarsPadding()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
+                .padding(horizontal = 16.dp),
             title = title,
             onBackClick = onBack
         )
@@ -84,8 +84,8 @@ fun <T> MediaLazyGrid(
                         HomeCard(
                             imageUrl = getImageUrl(item),
                             isSaved = isItemSaved(item),
-                            onSaveClick = { onSaveClick(item) },
-                            modifier = Modifier.clickable { onSaveClick(item)}
+                            onSaveClick = { /* todo on save click */ },
+                            modifier = Modifier.clickable { onItemClick(item) }
                         )
                     }
                 }

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
@@ -34,6 +34,7 @@ fun <T> MediaLazyGrid(
     getImageUrl: (T) -> String,
     modifier: Modifier = Modifier,
     onItemClick: (T) -> Unit = {},
+    onSavedClick: (T) -> Unit = {},
     isItemSaved: (T) -> Boolean = { false },
     isLoading: Boolean = false,
     emptyTitle: String = "",
@@ -88,7 +89,7 @@ fun <T> MediaLazyGrid(
                         HomeCard(
                             imageUrl = getImageUrl(item),
                             isSaved = isItemSaved(item),
-                            onSaveClick = { /* todo on save click */ },
+                            onSaveClick = { onSavedClick(item) },
                             modifier = Modifier.clickable { onItemClick(item) }
                         )
                     }

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -45,8 +47,10 @@ fun <T> MediaLazyGrid(
         TopBar(
             modifier = Modifier
                 .fillMaxWidth()
-                .statusBarsPadding()
-                .padding(horizontal = 16.dp),
+                .padding(horizontal = 16.dp)
+                .padding(
+                    top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 12.dp
+                ),
             title = title,
             onBackClick = onBack
         )


### PR DESCRIPTION
# What does this PR do?

This PR introduces the following changes to the Top Movies and Top TV Shows Picks screens:

- **Navigation on Item Click:**
    - `TopMoviesPicksScreen`: Clicking a movie now navigates to its details screen.
    - `TopTvShowsPicksScreen`: Clicking a TV show now navigates to its details screen.
- **Contract Updates:**
    - `TopMoviesPicksContract`: Added `onMovieClicked(movieId: Int)` function.
    - `TopTvShowsPicksContract`: Renamed `onSaveMovie` to `onSaveTvShow` for clarity.
- **ViewModel Updates:**
    - `TopMoviesPicksViewModel`: Implemented `onMovieClicked` to emit a navigation effect.
    - `TopTvShowsPicksViewModel`: Renamed `onSaveMovie` to `onSaveTvShow`.
- **Shared Composable (`MediaLazyGrid`):**
    - Renamed `onSaveClick` parameter to `onItemClick` to better reflect its purpose.
    - Removed vertical padding from the top app bar for a cleaner look.
- **File Renaming:**
    - `topMoviesPicksScreen.kt` renamed to `TopMoviesPicksScreen.kt`.
    - `topTvShowsPicksScreen.kt` renamed to `TopTvShowsPicksScreen.kt`.
