### PR TITLE
feat: implement saved list functionality

### DIFF
--- a/app/src/main/java/com/london/app/navigation/NovixApp.kt
+++ b/app/src/main/java/com/london/app/navigation/NovixApp.kt
@@ -325,8 +325,14 @@ fun NavGraphBuilder.mainNavGraph(
     ) {
         ListScreen(
             onNavigateToDetails = {
-                // id is dummy
-                navController.navigate(Screen.ViewListItems(8548075))
+                navController.navigate(Screen.ViewListItems(listId = it))
+            },
+            onNavigateToLogin = {
+                navController.navigate(Screen.Login) {
+                    popUpTo(NovixAppNavGraph.Main) {
+                        inclusive = true
+                    }
+                }
             }
         )
     }

--- a/data/src/main/java/com/london/data/remote/service/list/CustomMovieListsApiService.kt
+++ b/data/src/main/java/com/london/data/remote/service/list/CustomMovieListsApiService.kt
@@ -51,6 +51,7 @@ interface CustomMovieListsApiService {
 
     @GET("3/account/{account_id}/lists")
     suspend fun getAllUserLists(
-        @Query("session_id") sessionId: String?
+        @Query("session_id") sessionId: String?,
+        @Query("page") page: Int
     ): Response<ApiResponse<CustomMovieListResponse>>
 }

--- a/data/src/main/java/com/london/data/remote/source/list/CustomMovieListsRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/london/data/remote/source/list/CustomMovieListsRemoteDataSourceImpl.kt
@@ -96,7 +96,8 @@ class CustomMovieListsRemoteDataSourceImpl @Inject constructor(
     ): Result<ApiResponse<CustomMovieListResponse>> = callApiWithRetry(
         apiCall = {
             customMovieListsApiService.getAllUserLists(
-                sessionId = sessionId
+                sessionId = sessionId,
+                page = page
             )
         },
         mapper = { it }

--- a/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
@@ -54,7 +54,7 @@ fun AddListBottomSheet(
     if (addListSheetState.isSheetVisible) {
         ModalBottomSheet(
             onDismissRequest = {
-                addListInteractions.onAddListSheetDismiss()
+                addListInteractions.setAddListSheetVisible(false)
             },
             containerColor = NovixTheme.colors.surface,
             state = sheetState,
@@ -69,7 +69,7 @@ fun AddListBottomSheet(
                             sheetState.hide()
                         }.invokeOnCompletion {
                             if (!sheetState.isVisible) {
-                                addListInteractions.onAddListSheetDismiss()
+                                addListInteractions.setAddListSheetVisible(false)
                             }
                         }
                     }

--- a/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.london.designsystem.component.Icon
 import com.london.designsystem.component.ModalBottomSheet
 import com.london.designsystem.component.OutlinedTextField
@@ -34,15 +33,13 @@ import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
 import com.london.presentation.feature.list.savedlist.AddSheetState
 import com.london.presentation.feature.list.savedlist.ListContract
-import com.london.presentation.feature.list.savedlist.ListViewModel
 import com.london.presentation.feature.list.savedlist.defaultContractList
 import kotlinx.coroutines.launch
-import org.checkerframework.checker.units.qual.g
 
 @Composable
 fun AddListBottomSheet(
     modifier: Modifier = Modifier,
-    addListInteractions: ListContract = defaultContractList(),
+    addListInteractions: ListContract,
     sheetState: SheetState = rememberModalBottomSheetState(),
     addListSheetState: AddSheetState,
 ) {

--- a/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/bottomsheets/addListBottomSheet.kt
@@ -37,11 +37,12 @@ import com.london.presentation.feature.list.savedlist.ListContract
 import com.london.presentation.feature.list.savedlist.ListViewModel
 import com.london.presentation.feature.list.savedlist.defaultContractList
 import kotlinx.coroutines.launch
+import org.checkerframework.checker.units.qual.g
 
 @Composable
 fun AddListBottomSheet(
     modifier: Modifier = Modifier,
-    addListInteractions: ListContract = hiltViewModel<ListViewModel>(),
+    addListInteractions: ListContract = defaultContractList(),
     sheetState: SheetState = rememberModalBottomSheetState(),
     addListSheetState: AddSheetState,
 ) {
@@ -77,7 +78,7 @@ fun AddListBottomSheet(
                     }
                 },
                 onAddClicked = {
-                    addListInteractions.onAddList(addListSheetState.listName)
+                    addListInteractions.onAddList(addListSheetState.listName.text)
                 }
             )
         }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListEffect.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListEffect.kt
@@ -2,5 +2,5 @@ package com.london.presentation.feature.list.savedlist
 
 sealed interface ListEffect {
     data class NavigateToDetails(val id: Int) : ListEffect
-    object ShowAddListSheet : ListEffect
+    object NavigateToLogin : ListEffect
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListItemUi.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListItemUi.kt
@@ -1,7 +1,0 @@
-package com.london.presentation.feature.list.savedlist
-
-data class ListItemUi(
-    val id: Int,
-    val title: String,
-    val count: Int
-)

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListViewModel.kt
@@ -1,74 +1,133 @@
 package com.london.presentation.feature.list.savedlist
 
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.paging.PagingData
-import com.london.domain.entity.recent.MediaType
+import com.london.domain.usecase.LoggedInUseCase
+import com.london.domain.usecase.movielist.GetAllMovieListsUseCase
+import com.london.domain.usecase.movielist.ManageMovieListUseCase
 import com.london.presentation.shared.base.BaseViewModel
+import com.london.presentation.shared.base.createPagingSourceFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 
 @HiltViewModel
-class ListViewModel @Inject constructor() :
-    BaseViewModel<ListUiState, ListEffect>(ListUiState()), ListContract {
+class ListViewModel @Inject constructor(
+    private val getAllMovieListsUseCase: GetAllMovieListsUseCase,
+    private val manageMovieListUseCase: ManageMovieListUseCase,
+    private val loggedInUseCase: LoggedInUseCase
+) : BaseViewModel<ListUiState, ListEffect>(ListUiState()), ListContract {
 
     init {
-        getSavedLists()
+
+        checkUserLoginStatus { isLoggedIn->
+            if (!isLoggedIn) return@checkUserLoginStatus
+            fetchSavedLists()
+        }
     }
 
-    override fun onRetry() {
-        // TODO("Not yet implemented")
-    }
+    override fun onRetry() { fetchSavedLists() }
 
-    override fun onLoginClick() {
-        // TODO("Not yet implemented")
-    }
+    override fun onFabClick() = showAddListSheet()
+
+    override fun showBottomSheet() = setAddListSheetVisible(false)
+
+    override fun onAddListSheetDismiss() = setAddListSheetVisible(false)
+
+    override fun onLoginClick() { emitEffect(ListEffect.NavigateToLogin) }
 
     override fun onListClick(id: Int) {
+
+        updateState { copy(isSnackBarSuccessVisible = false) }
         emitEffect(ListEffect.NavigateToDetails(id))
     }
 
-    override fun onFabClick() {
-        /*TODO*/
-    }
-
-    override fun onAddList(listName: TextFieldValue) {
-        TODO("Not yet implemented")
-    }
-
-    override fun onAddListSheetDismiss() {
-        /*TODO*/
-    }
-
     override fun onListNameChanged(listName: TextFieldValue) {
-        /*TODO*/
-    }
 
-    override fun onMediaTypeChanged(mediaType: MediaType) {
-        /*TODO*/
-    }
-
-    override fun showAddListSheet(mediaType: MediaType) {
-        /*TODO*/
-    }
-
-
-    private fun dummyItems(): Flow<PagingData<ListItemUi>> {
-        val list =  //emptyList<SavedListItemUi>()
-            List(5) { index ->
-                ListItemUi(
-                    id = index,
-                    title = "Dummy List #$index",
-                    count = (1..10).random()
-                )
-            }
-        return flowOf(PagingData.from(list))
-    }
-
-    private fun getSavedLists() {
         updateState {
-            copy(isLoading = false, items = dummyItems())
+            copy(addListSheetState = addListSheetState.copy(listName = listName))
+        }
+    }
+
+    override fun onAddList(listName: String) {
+
+        tryToExecute(
+            onStart = {
+                updateState { copy(isSnackBarSuccessVisible = false,isLoading = true) }
+            },
+            block = {
+                manageMovieListUseCase.createMovieList(listName)
+            },
+            onError = {
+                updateState { copy(error = it, isLoading = false) }
+            },
+            onSuccess = {
+                onAddListSheetDismiss()
+                updateState {
+                    copy(
+                        isSnackBarSuccessVisible = true,
+                        isLoading = false,
+                        addListSheetState = addListSheetState.copy(
+                            listName = TextFieldValue(""),
+                        )
+                    )
+                }
+                fetchSavedLists()
+            }
+        )
+    }
+
+    private fun fetchSavedLists() {
+
+        tryToExecute(
+            block = {
+                val moviesFlow = createPagingSourceFlow(query = "") { _, pageNumber ->
+                    val movies = getAllMovieListsUseCase.invoke(
+                        pageNumber
+                    )
+                    movies.copy(items = movies.items)
+                }
+                moviesFlow
+            },
+            onStart = {
+                updateState { copy(isLoading = true) }
+            },
+            onSuccess = { moviesFlow ->
+                updateState {
+                    copy(items = moviesFlow)
+                }
+            },
+            onError = { errorState ->
+                updateState {
+                    copy(error = errorState)
+                }
+            },
+            onCompleted = { updateState { copy(isLoading = false) } },
+        )
+    }
+
+    private fun showAddListSheet() = setAddListSheetVisible(true)
+
+    private fun checkUserLoginStatus(onResult: (Boolean) -> Unit = {}) {
+
+        tryToExecute(
+            block = { loggedInUseCase.invoke() },
+            onStart = {
+                updateState { copy(isLoading = true) }
+            },
+            onSuccess = { isLoggedIn ->
+                updateState { copy(isGuest = !isLoggedIn, isLoading = false) }
+                onResult(isLoggedIn)
+            },
+            onError = {
+                updateState { copy(isGuest = true, isLoading = false) }
+                onResult(false)
+            },
+        )
+    }
+
+    private fun setAddListSheetVisible(visible: Boolean) {
+
+        updateState {
+            copy(addListSheetState = addListSheetState.copy(isSheetVisible = visible))
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListViewModel.kt
@@ -26,11 +26,8 @@ class ListViewModel @Inject constructor(
 
     override fun onRetry() { fetchSavedLists() }
 
-    override fun onFabClick() = showAddListSheet()
+    override fun onFabClick() = setAddListSheetVisible(true)
 
-    override fun showBottomSheet() = setAddListSheetVisible(false)
-
-    override fun onAddListSheetDismiss() = setAddListSheetVisible(false)
 
     override fun onLoginClick() { emitEffect(ListEffect.NavigateToLogin) }
 
@@ -40,6 +37,12 @@ class ListViewModel @Inject constructor(
         emitEffect(ListEffect.NavigateToDetails(id))
     }
 
+    override fun setAddListSheetVisible(visible: Boolean) {
+
+        updateState {
+            copy(addListSheetState = addListSheetState.copy(isSheetVisible = visible))
+        }
+    }
     override fun onListNameChanged(listName: TextFieldValue) {
 
         updateState {
@@ -60,7 +63,7 @@ class ListViewModel @Inject constructor(
                 updateState { copy(error = it, isLoading = false) }
             },
             onSuccess = {
-                onAddListSheetDismiss()
+                setAddListSheetVisible(false)
                 updateState {
                     copy(
                         isSnackBarSuccessVisible = true,
@@ -104,8 +107,6 @@ class ListViewModel @Inject constructor(
         )
     }
 
-    private fun showAddListSheet() = setAddListSheetVisible(true)
-
     private fun checkUserLoginStatus(onResult: (Boolean) -> Unit = {}) {
 
         tryToExecute(
@@ -122,12 +123,5 @@ class ListViewModel @Inject constructor(
                 onResult(false)
             },
         )
-    }
-
-    private fun setAddListSheetVisible(visible: Boolean) {
-
-        updateState {
-            copy(addListSheetState = addListSheetState.copy(isSheetVisible = visible))
-        }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listContract.kt
@@ -4,27 +4,26 @@ import androidx.compose.ui.text.input.TextFieldValue
 import com.london.domain.entity.recent.MediaType
 
 interface ListContract {
-    fun onRetry()
-    fun onLoginClick()
-    fun onListClick(id: Int)
-    fun onFabClick()
 
-    fun onAddList(listName: TextFieldValue)
+    fun onRetry()
+    fun onFabClick()
+    fun onLoginClick()
+    fun showBottomSheet()
+    fun onListClick(id: Int)
     fun onAddListSheetDismiss()
+    fun onAddList(listName: String)
     fun onListNameChanged(listName: TextFieldValue)
-    fun onMediaTypeChanged(mediaType: MediaType)
-    fun showAddListSheet(mediaType: MediaType = MediaType.Movie)
 }
 
 
 fun defaultContractList() = object : ListContract {
+
     override fun onRetry() {}
-    override fun onLoginClick() {}
-    override fun onListClick(id: Int) {}
     override fun onFabClick() {}
-    override fun onAddList(listName: TextFieldValue) {}
+    override fun onLoginClick() {}
+    override fun showBottomSheet() {}
+    override fun onListClick(id: Int) {}
     override fun onAddListSheetDismiss() {}
+    override fun onAddList(listName: String) {}
     override fun onListNameChanged(listName: TextFieldValue) {}
-    override fun onMediaTypeChanged(mediaType: MediaType) {}
-    override fun showAddListSheet(mediaType: MediaType) {}
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listContract.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listContract.kt
@@ -8,10 +8,9 @@ interface ListContract {
     fun onRetry()
     fun onFabClick()
     fun onLoginClick()
-    fun showBottomSheet()
     fun onListClick(id: Int)
-    fun onAddListSheetDismiss()
     fun onAddList(listName: String)
+    fun setAddListSheetVisible(visible: Boolean)
     fun onListNameChanged(listName: TextFieldValue)
 }
 
@@ -21,9 +20,8 @@ fun defaultContractList() = object : ListContract {
     override fun onRetry() {}
     override fun onFabClick() {}
     override fun onLoginClick() {}
-    override fun showBottomSheet() {}
     override fun onListClick(id: Int) {}
-    override fun onAddListSheetDismiss() {}
     override fun onAddList(listName: String) {}
+    override fun setAddListSheetVisible(visible: Boolean) {}
     override fun onListNameChanged(listName: TextFieldValue) {}
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listScreen.kt
@@ -43,7 +43,10 @@ import com.london.designsystem.component.button.OutlineButton
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.ThemePreviews
 import com.london.designsystem.utils.painter
+import com.london.domain.entity.MovieList
 import com.london.presentation.R
+import com.london.presentation.feature.list.bottomsheets.AddListBottomSheet
+import com.london.presentation.shared.SnackBarAnimation
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
@@ -51,6 +54,7 @@ import com.london.presentation.utils.Listen
 @Composable
 fun ListScreen(
     onNavigateToDetails: (Int) -> Unit,
+    onNavigateToLogin: () -> Unit,
     viewModel: ListViewModel = hiltViewModel()
 ) {
 
@@ -60,7 +64,7 @@ fun ListScreen(
     effect?.Listen { currentEffect ->
         when (currentEffect) {
             is ListEffect.NavigateToDetails -> onNavigateToDetails(currentEffect.id)
-            ListEffect.ShowAddListSheet -> TODO()
+            ListEffect.NavigateToLogin -> onNavigateToLogin()
         }
     }
 
@@ -150,6 +154,21 @@ private fun Content(
                     )
                 }
             }
+            AddListBottomSheet(
+                addListInteractions = contract,
+                addListSheetState = state.addListSheetState
+            )
+        }
+        if (state.isSnackBarSuccessVisible){
+            SnackBarAnimation(
+                message = stringResource(R.string.list_added_successfly),
+                icon = com.london.designsystem.R.drawable.ic_success
+            )
+        }
+        if (state.error!=null){
+            SnackBarAnimation(
+                message = stringResource(R.string.can_not_delete_list)
+            )
         }
     }
 
@@ -157,14 +176,14 @@ private fun Content(
 
 @Composable
 private fun SavedListItemRow(
-    itemUi: ListItemUi,
+    itemUi: MovieList,
     onCountClick: (Int) -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
-            .clickable { onCountClick(itemUi.id) }
+            .clickable { onCountClick(itemUi.id.toInt()) }
             .background(NovixTheme.colors.surface)
             .border(
                 width = 1.dp,
@@ -174,7 +193,7 @@ private fun SavedListItemRow(
             .padding(horizontal = 12.dp, vertical = 16.dp)
     ) {
         Text(
-            text = itemUi.title,
+            text = itemUi.name,
             style = NovixTheme.typography.title.medium,
             color = NovixTheme.colors.title,
             maxLines = 1,
@@ -189,7 +208,7 @@ private fun SavedListItemRow(
 
 @Composable
 private fun ItemCount(
-    itemUi: ListItemUi,
+    itemUi: MovieList,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -200,7 +219,7 @@ private fun ItemCount(
             .padding(horizontal = 8.dp, vertical = 4.dp)
     ) {
         Text(
-            text = itemUi.count.toString(),
+            text = itemUi.moviesCount.toString(),
             style = NovixTheme.typography.label.small,
             color = NovixTheme.colors.primary,
         )

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -147,11 +146,15 @@ private fun Content(
                     .padding(horizontal = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(pagingItems.itemSnapshotList.items) { item ->
-                    SavedListItemRow(
-                        itemUi = item,
-                        onCountClick = contract::onListClick
-                    )
+                items(pagingItems.itemCount) { index ->
+                    val item = pagingItems[index]
+                    if (item != null) {
+                        SavedListItemRow(
+                            itemUi = item,
+                            onCountClick = contract::onListClick
+                        )
+                    }
+
                 }
             }
             AddListBottomSheet(
@@ -159,13 +162,13 @@ private fun Content(
                 addListSheetState = state.addListSheetState
             )
         }
-        if (state.isSnackBarSuccessVisible){
+        if (state.isSnackBarSuccessVisible) {
             SnackBarAnimation(
                 message = stringResource(R.string.list_added_successfly),
                 icon = com.london.designsystem.R.drawable.ic_success
             )
         }
-        if (state.error!=null){
+        if (state.error != null) {
             SnackBarAnimation(
                 message = stringResource(R.string.can_not_delete_list)
             )

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listUiState.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/listUiState.kt
@@ -2,26 +2,24 @@ package com.london.presentation.feature.list.savedlist
 
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.paging.PagingData
+import com.london.domain.entity.MovieList
 import com.london.domain.entity.recent.MediaType
 import com.london.presentation.shared.base.ErrorState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 data class ListUiState(
-    val isLoading: Boolean = false,
     val isGuest: Boolean = false,
     val error: ErrorState? = null,
-    val items: Flow<PagingData<ListItemUi>> = flow {},
-    val errorMessage: String? = null,
+    val isLoading: Boolean = false,
+    val isSnackBarSuccessVisible: Boolean = false,
+    val items: Flow<PagingData<MovieList>> = flow {},
     val addListSheetState: AddSheetState = AddSheetState(),
 )
 
 data class AddSheetState(
     val listName: TextFieldValue = TextFieldValue(""),
-    val originalListName: String = "",
     val isSheetVisible: Boolean = false,
-    val listId: Int? = null,
-    val mediaType: MediaType = MediaType.Movie,
     val isSheetLoading: Boolean = false,
     val errorMessage: String? = null,
 )

--- a/presentation/src/main/java/com/london/presentation/shared/buildscreen/BuildScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/buildscreen/BuildScreen.kt
@@ -52,7 +52,7 @@ fun BuildScreen(
     isLoading: Boolean = false,
     isError: Boolean = false,
     isGuest: Boolean = false,
-    onBack: () -> Unit = {},
+    onBack: (() -> Unit)? = {},
     onRetry: () -> Unit = {},
     @StringRes emptyLayoutMessage: Int? = null,
     @DrawableRes emptyLayoutImage: Int? = null,

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -143,4 +143,6 @@
     <string name="no_content_is_blurred">لا يتم تمويه أي محتوى.</string>
     <string name="movie_removed_successfully">تم حذف الفيلم بنجاح</string>
     <string name="movie_not_found">الفيلم غير موجود</string>
+    <string name="list_added_successfly">تم اضافه القائمه بنجاح</string>
+    <string name="can_not_delete_list">حدث خطا ما لا يمكن اضافه القائمه</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -143,4 +143,6 @@
     <string name="no_content_is_blurred">No content is blurred.</string>
     <string name="movie_removed_successfully">movie removed successffly</string>
     <string name="movie_not_found">movie not found</string>
+    <string name="list_added_successfly">list added successfuly</string>
+    <string name="can_not_delete_list">can not delete list</string>
 </resources>


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
- Implements the ability to fetch and display saved lists for logged-in users.
- Adds functionality to create new lists via a bottom sheet.
- Handles user interactions such as clicking on a list item (navigates to details) and clicking the FAB (shows the "add list" bottom sheet).
- Manages loading, error, and guest states.
- Displays success/error snackbars for list creation.
- Navigates to the login screen if a guest user attempts to access list features.
- Deletes the unused `ListItemUi.kt` file.
- Adds new string resources for list creation success and failure messages.
- Modifies `BuildScreen` to allow a nullable `onBack` callback.
- Updates `AddListBottomSheet` to use the correct contract and pass the list name text.
- Refactors `ListViewModel` to integrate with use cases for fetching and managing movie lists, and checking login status.
- Updates `ListScreen` to use the new `ListViewModel` and handle its effects, including navigation to login and displaying snackbars.
- Updates `SavedListItemRow` to display `MovieList` data.
- Updates `NovixApp` navigation for the list screen to handle navigation to list items and login.
- Modifies `ListEffect` to include `NavigateToLogin`.
- Updates `ListUiState` and `AddSheetState` to reflect the new state requirements.
- Updates `ListContract` to align with the new view model interactions.
## Type of Change
- [x] ✨ New feature
- [x] 🎨 UI changes
## Changes Made
- [x] Compose UI
## Checklist
- [x] Ready for review
