### PR TITLE
fix: Error image dark mode

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/button/ErrorImageBox.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/button/ErrorImageBox.kt
@@ -1,7 +1,6 @@
 package com.london.designsystem.component.button
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -11,11 +10,10 @@ import androidx.compose.ui.unit.dp
 import com.london.designsystem.R
 
 @Composable
-fun ErrorImage() {
-    val isDarkTheme = isSystemInDarkTheme()
+fun ErrorImage(isDarkMode: Boolean) {
     Image(
         painter = painterResource(
-            if (isDarkTheme) R.drawable.img_error_dark else R.drawable.img_error_light
+            if (isDarkMode) R.drawable.img_error_dark else R.drawable.img_error_light
         ),
         contentDescription = stringResource(R.string.error_image),
         modifier = Modifier.size(56.dp)

--- a/presentation/src/main/java/com/london/presentation/feature/account/AccountViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/account/AccountViewModel.kt
@@ -30,6 +30,7 @@ class AccountViewModel @Inject constructor(
         fetchAndSetUsername()
         observeContentRestrictionLevel()
         initializeAppLanguage()
+        initializeAppTheme()
     }
 
     private fun checkUserLoginStatus() {

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/actorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/actorDetailsScreen.kt
@@ -315,7 +315,8 @@ fun TopMoviesPicksList(
                 onSaveClick = { /* TODO: Not yet implemented */ },
                 modifier = Modifier.clickable {
                     onNavigateToMoviePicks(movie[index].id)
-                }
+                },
+                isDarkMode = NovixTheme.isThemeDark
             )
         }
     }
@@ -339,7 +340,8 @@ fun TopTvShowsPicksList(
                 onSaveClick = { /* TODO: Not yet implemented */ },
                 modifier = Modifier.clickable {
                     onNavigateToTvShowPicks(tvShow[index].id)
-                }
+                },
+                isDarkMode = NovixTheme.isThemeDark
             )
         }
     }
@@ -365,7 +367,7 @@ fun ActorGallery(images: List<ImageDetails>) {
                         color = NovixTheme.colors.stroke
                     )
                     .clip(RoundedCornerShape(12.dp)),
-                errorContent = { ErrorImage() },
+                errorContent = { ErrorImage(NovixTheme.isThemeDark) },
                 loadingContent = { CircularLoading(modifier = Modifier) }
             )
         }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/actorGalleryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actordetails/gallery/actorGalleryScreen.kt
@@ -103,7 +103,7 @@ private fun Content(
                                 .clip(RoundedCornerShape(12.dp)),
                             contentScale = ContentScale.Crop,
                             loadingContent = { CircularLoading() },
-                            errorContent = { ErrorImage() }
+                            errorContent = { ErrorImage(NovixTheme.isThemeDark) }
                         )
                     }
                 }
@@ -111,4 +111,3 @@ private fun Content(
         }
     }
 }
-

--- a/presentation/src/main/java/com/london/presentation/feature/details/movie/movieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movie/movieDetailsScreen.kt
@@ -53,9 +53,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.R
-import com.london.presentation.shared.ActorItem
 import com.london.designsystem.component.GuestUserLoginBottomSheet
-import com.london.presentation.shared.HomeCard
 import com.london.designsystem.component.Icon
 import com.london.designsystem.component.RatingBottomSheet
 import com.london.designsystem.component.Text
@@ -76,8 +74,8 @@ import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.FooterSection
 import com.london.presentation.shared.HomeCard
-import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.shared.SnackBarAnimation
+import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertGenreCodeToString
 import com.london.presentation.utils.getLocalizedTimeUnit
@@ -312,7 +310,8 @@ fun MovieDetailsContent(
                         modifier = Modifier
                             .clickable {
                                 movieDetailsContract.onMovieClick(movie.id)
-                            }
+                            },
+                        isDarkMode = NovixTheme.isThemeDark
                     )
                 }
             }

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/tvShowDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/tvshowdetails/tvShowDetailsScreen.kt
@@ -585,7 +585,7 @@ private fun EpisodeItem(
                 .height(78.dp)
                 .weight(0.35f),
             loadingContent = { CircularLoading() },
-            errorContent = { ErrorImage() },
+            errorContent = { ErrorImage(NovixTheme.isThemeDark) },
             moderatedContent = { UnSuitableEye() }
         )
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -375,7 +375,8 @@ private fun LazyGridScope.upComingSection(
                     modifier = Modifier
                         .clipToBounds()
                         .clip(RoundedCornerShape(12.dp))
-                        .clickable { contract.onMovieClick(movie.id) }
+                        .clickable { contract.onMovieClick(movie.id) },
+                    isDarkMode = NovixTheme.isThemeDark
                 )
             }
         }

--- a/presentation/src/main/java/com/london/presentation/feature/home/popular/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/popular/PopularSection.kt
@@ -143,7 +143,8 @@ fun PopularSection(
                             uiMediaList[page].id,
                             uiMediaList[page].mediaType
                         )
-                    }
+                    },
+                    isDarkMode = NovixTheme.isThemeDark
                 )
                 if (pagerState.currentPage == page)
                     Column(

--- a/presentation/src/main/java/com/london/presentation/feature/home/section/CarouselSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/section/CarouselSection.kt
@@ -77,7 +77,8 @@ fun HomeCarouselSection(
                     },
                 imageUrl = mediaItem.posterUrl,
                 onSaveClick = { onSaveClick(mediaItem.id) },
-                hasSaveIcon = isHero
+                hasSaveIcon = isHero,
+                isDarkMode = NovixTheme.isThemeDark
             )
         }
     }

--- a/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
@@ -149,7 +149,8 @@ private fun Content(
                             },
                             modifier = Modifier.clickable {
                                 topRatedContract.onMovieClick(movieItem.id)
-                            }
+                            },
+                            isDarkMode = NovixTheme.isThemeDark
                         )
                     }
                 }
@@ -165,7 +166,8 @@ private fun Content(
                         },
                         modifier = Modifier.clickable {
                             topRatedContract.onTvShowClick(seriesItem.id)
-                        }
+                        },
+                        isDarkMode = NovixTheme.isThemeDark
                     )
                 }
             }

--- a/presentation/src/main/java/com/london/presentation/feature/onboarding/welcomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/onboarding/welcomeScreen.kt
@@ -2,7 +2,6 @@ package com.london.presentation.feature.onboarding
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -138,7 +137,7 @@ fun WelcomePoster(modifier: Modifier = Modifier) {
         modifier = modifier,
         contentAlignment = Alignment.BottomCenter
     ) {
-        val image = if (isSystemInDarkTheme()) {
+        val image = if (NovixTheme.isThemeDark) {
             painterResource(id = R.drawable.welcome_screen_dark)
         } else {
             painterResource(id = R.drawable.welcome_screen_light)

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/reviewsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/reviewsScreen.kt
@@ -229,7 +229,7 @@ fun AuthorItem(
                 contentDescription = stringResource(R.string.author_profile),
                 contentScale = ContentScale.Crop,
                 loadingContent = { CircularLoading() },
-                errorContent = { ErrorImage() },
+                errorContent = { ErrorImage(NovixTheme.isThemeDark) },
             )
         }
         Column(

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -520,7 +520,8 @@ fun RecentViewedSection(
                         MediaType.Movie -> onNavigateToMovieDetails(item.id)
                         MediaType.TvShow -> onNavigateToTvShowDetails(item.id)
                     }
-                }
+                },
+                isDarkMode = NovixTheme.isThemeDark
             )
         }
     }

--- a/presentation/src/main/java/com/london/presentation/shared/ActorItem.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/ActorItem.kt
@@ -82,7 +82,7 @@ private fun ActorImage(
                 ),
             contentScale = ContentScale.Crop,
             loadingContent = { CircularLoading(modifier = Modifier.align(Alignment.Center)) },
-            errorContent = { ErrorImage() },
+            errorContent = { ErrorImage(NovixTheme.isThemeDark) },
             moderatedContent = { UnSuitableEye(isSmallPicture = true) }
         )
     }

--- a/presentation/src/main/java/com/london/presentation/shared/CategoryItem.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/CategoryItem.kt
@@ -52,7 +52,7 @@ fun CategoriesItem(
     ) {
         ImageView(
             model = categoryImage,
-            errorContent = { ErrorImage() },
+            errorContent = { ErrorImage(NovixTheme.isThemeDark) },
             contentDescription = "Image of ${categoryName.joinToString()}",
             modifier = Modifier.fillMaxSize(),
             contentScale = Crop,

--- a/presentation/src/main/java/com/london/presentation/shared/CustomBackDropImagePager.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/CustomBackDropImagePager.kt
@@ -45,7 +45,7 @@ fun CustomBackDropImagePager(
             contentAlignment = Alignment.Center
         ) {
             ImageVerticalGradient()
-            ErrorImage()
+            ErrorImage(NovixTheme.isThemeDark)
         }
     } else {
         Box(
@@ -85,7 +85,7 @@ fun CustomBackDropImagePager(
                     contentScale = ContentScale.Crop,
                     model = validImages[pageIndex],
                     contentDescription = "${stringResource(R.string.tv_show_image)} ${pageIndex + 1}",
-                    errorContent = { ErrorImage() },
+                    errorContent = { ErrorImage(NovixTheme.isThemeDark) },
                     loadingContent = { CircularLoading(modifier = Modifier) },
                     moderatedContent = { UnSuitableEye() }
                 )

--- a/presentation/src/main/java/com/london/presentation/shared/HomeCard.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/HomeCard.kt
@@ -22,6 +22,7 @@ import com.london.designsystem.theme.ThemePreviews
 @Composable
 fun HomeCard(
     imageUrl: Any,
+    isDarkMode: Boolean,
     modifier: Modifier = Modifier,
     isSaved: Boolean = false,
     hasSaveIcon: Boolean = true,
@@ -48,7 +49,7 @@ fun HomeCard(
             contentDescription = imageDescription,
             modifier = Modifier.matchParentSize(),
             contentScale = ContentScale.Crop,
-            errorContent = { ErrorImage() },
+            errorContent = { ErrorImage(isDarkMode = isDarkMode) },
             loadingContent = { CircularLoading(modifier = Modifier.align(Alignment.Center)) },
             moderatedContent = { UnSuitableEye() }
         )
@@ -71,7 +72,8 @@ fun HomeCardPreview() {
         HomeCard(
             imageUrl = "https://image.tmdb.org/t/p/w500/rktDFPbfHfUbArZ6OOOKsXcv0Bm.jpg",
             isSaved = false,
-            onSaveClick = {}
+            onSaveClick = {},
+            isDarkMode = true
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
@@ -90,7 +90,8 @@ fun <T> MediaLazyGrid(
                             imageUrl = getImageUrl(item),
                             isSaved = isItemSaved(item),
                             onSaveClick = { onSavedClick(item) },
-                            modifier = Modifier.clickable { onItemClick(item) }
+                            modifier = Modifier.clickable { onItemClick(item) },
+                            isDarkMode = NovixTheme.isThemeDark
                         )
                     }
                 }

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyPagingGrid.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.utils.gridColmuns
 
 @Composable
@@ -39,7 +40,8 @@ fun <T : Any> MediaLazyPagingGrid(
                     onSaveClick = { onSaveClick(item) },
                     isSaved = isItemSaved(item),
                     imageDescription = getTitle(item),
-                    modifier = Modifier.clickable { onItemClick(item) }
+                    modifier = Modifier.clickable { onItemClick(item) },
+                    isDarkMode = NovixTheme.isThemeDark
                 )
             }
         }

--- a/presentation/src/main/java/com/london/presentation/shared/MoviesLayout.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MoviesLayout.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.Movie
 import com.london.presentation.utils.gridColmuns
 
@@ -36,7 +37,8 @@ fun MoviesLayOut(
                     onSaveClick = { onSaveClick(movie) },
                     isSaved = isMovieSaved(movie),
                     imageDescription = movie.name,
-                    modifier = Modifier.clickable { onMovieClick(movie) }
+                    modifier = Modifier.clickable { onMovieClick(movie) },
+                    isDarkMode = NovixTheme.isThemeDark
                 )
             }
         }

--- a/presentation/src/main/java/com/london/presentation/shared/TvShowsLayout.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/TvShowsLayout.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.paging.compose.LazyPagingItems
+import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.TvShow
 import com.london.presentation.utils.gridColmuns
 
@@ -38,7 +39,8 @@ fun TvShowLayOut(
                     onSaveClick = { onSaveClick(tvShow) },
                     isSaved = isTvShowSaved(tvShow),
                     imageDescription = tvShow.name,
-                    modifier = Modifier.clickable { onTvShowClick(tvShow) }
+                    modifier = Modifier.clickable { onTvShowClick(tvShow) },
+                    isDarkMode = NovixTheme.isThemeDark
                 )
             }
         }

--- a/presentation/src/main/java/com/london/presentation/shared/continuewatching/ContinueWatchingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/continuewatching/ContinueWatchingScreen.kt
@@ -212,7 +212,8 @@ private fun MediaGrid(
                 items(tvSeries) { series ->
                     TvSeriesCard(
                         series = series,
-                        onSeriesClick = continueWatchingContract::onNavigateToTvShow
+                        onSeriesClick = continueWatchingContract::onNavigateToTvShow,
+                        isDarkMode = NovixTheme.isThemeDark
                     )
                 }
             }
@@ -229,20 +230,23 @@ private fun MovieCard(
         imageUrl = movie.posterUrl,
         isSaved = false,
         onSaveClick = { /* TODO */ },
-        modifier = Modifier.clickable { onMovieClick(movie.id) }
+        modifier = Modifier.clickable { onMovieClick(movie.id) },
+        isDarkMode = NovixTheme.isThemeDark
     )
 }
 
 @Composable
 private fun TvSeriesCard(
     series: TvShow,
-    onSeriesClick: (Int) -> Unit
+    onSeriesClick: (Int) -> Unit,
+    isDarkMode: Boolean
 ) {
     HomeCard(
         imageUrl = series.posterPicture,
         isSaved = false,
         onSaveClick = { /* TODO */ },
-        modifier = Modifier.clickable { onSeriesClick(series.id) }
+        modifier = Modifier.clickable { onSeriesClick(series.id) },
+        isDarkMode = isDarkMode
     )
 }
 


### PR DESCRIPTION
# What does this PR do?
Fixes an issue where icons’ dark theme appearance depended on the system theme instead of the app’s selected theme.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI

## Checklist
- [x] Code builds without warnings
- [x] Self-reviewed
- [x] Tests pass
- [x] Ready for review
