### PR TITLE
refactor: Update rating type to String for localization

### DIFF
--- a/designSystem/src/main/java/com/london/designsystem/component/MyRatingIcon.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/MyRatingIcon.kt
@@ -22,7 +22,7 @@ import com.london.designsystem.theme.ThemePreviews
 @Composable
 fun MyRatingIcon(
     modifier: Modifier = Modifier,
-    rate: Int
+    rate: String
 ) {
     Row(
         modifier = modifier
@@ -44,7 +44,7 @@ fun MyRatingIcon(
             tint =  NovixTheme.colors.yellowAccent,
         )
         Text(
-            text = rate.toString(),
+            text = rate,
             style = NovixTheme.typography.label.small,
             color = NovixTheme.colors.onPrimary
         )
@@ -56,7 +56,7 @@ fun MyRatingIcon(
 fun MyRatingIconPreview() {
     NovixTheme {
         MyRatingIcon(
-            rate = 4
+            rate = "4"
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/myrating/MyRatingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/myrating/MyRatingScreen.kt
@@ -34,6 +34,7 @@ import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.gridColmuns
+import com.london.presentation.utils.toLocalizedNumbers
 import com.london.designsystem.R as dsR
 
 @Composable
@@ -128,7 +129,7 @@ private fun MyRatingContent(
                         isSaved = false,
                         onSaveClick = { },
                         myRatingList = true,
-                        rate = item.rating,
+                        rate = item.rating.toLocalizedNumbers(),
                         onDeleteClick = { contract.onDelete(item.id) },
                         modifier = Modifier.clickable {
                             when {
@@ -168,17 +169,17 @@ fun RatingChipsRow(
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         NovixChip(
-            text = "All",
+            text = stringResource(R.string.all),
             isSelected = selected == RatingCategory.All,
             onClick = { onSelect(RatingCategory.All) }
         )
         NovixChip(
-            text = "Movies",
+            text = stringResource(R.string.Movies),
             isSelected = selected == RatingCategory.Movies,
             onClick = { onSelect(RatingCategory.Movies) }
         )
         NovixChip(
-            text = "TV Shows",
+            text = stringResource(R.string.TV_Shows),
             isSelected = selected == RatingCategory.TvShows,
             onClick = { onSelect(RatingCategory.TvShows) }
         )

--- a/presentation/src/main/java/com/london/presentation/shared/HomeCard.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/HomeCard.kt
@@ -29,7 +29,7 @@ fun HomeCard(
     isSaved: Boolean = false,
     hasSaveIcon: Boolean = true,
     myRatingList: Boolean = false,
-    rate: Int = 5,
+    rate: String = "5",
     onDeleteClick: () -> Unit = {},
     imageDescription: String? = null,
     onSaveClick: () -> Unit,

--- a/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/MediaLazyGrid.kt
@@ -40,7 +40,7 @@ fun <T> MediaLazyGrid(
     emptyTitle: String = "",
     emptyImage: Int? = null,
     myRatingList: Boolean = false,
-    rate: Int = 5,
+    rate: String = "5",
     onDeleteClick: () -> Unit = {}
 ) {
     Column(


### PR DESCRIPTION
# What does this PR do?
This PR changes the data type of the `rate` property in various UI components from `Int` to `String` and translate genres to arabic.

This change enables the display of localized numbers for ratings, improving the user experience for users in different regions.

The affected components include:
- `MyRatingScreen`
- `MediaLazyGrid`
- `HomeCard`
- `MyRatingIcon`

Additionally, string resources are now used for chip labels in `MyRatingScreen` for better internationalization.

## Type of Change
- [x] 🐛 Bug fix

## Changes Made
- [x] Compose UI


## Screenshots
<img width="431" height="822" alt="image" src="https://github.com/user-attachments/assets/3c4803fa-7881-4744-bf39-9a08f456fc32" />


## Checklist
- [x] Ready for review
