### PR TITLE
Refactor: Remove redundant parameters in SearchViewModel

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchCategory.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchCategory.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import com.london.presentation.R
 
 enum class SearchCategory(@StringRes val title: Int) {
-    Actors(R.string.Actors),
     Movies(R.string.Movies),
-    TvShows(R.string.TV_Shows)
+    TvShows(R.string.TV_Shows),
+    Actors(R.string.Actors)
 }

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchViewModel.kt
@@ -47,8 +47,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            onCompleted = { },
-            checkSuccess = { true }
         )
     }
 
@@ -110,7 +108,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 
@@ -187,7 +184,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 
@@ -201,7 +197,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 
@@ -216,7 +211,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 
@@ -230,7 +224,6 @@ class SearchViewModel @Inject constructor(
             onError = { errorState ->
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 
@@ -308,7 +301,6 @@ class SearchViewModel @Inject constructor(
                 clearAllSearchResults()
                 updateState { copy(error = errorState) }
             },
-            checkSuccess = { true }
         )
     }
 


### PR DESCRIPTION
# What does this PR do?

- Removed `onCompleted` and `checkSuccess` parameters from various functions in `SearchViewModel` as they were unused or always returned true.
- Reordered `SearchCategory` enum entries for consistency.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
