### PR TITLE
hotfix: home top rated section duplication 

### DIFF
--- a/data/src/main/java/com/london/data/mapper/home/toprated/TopRatedMediaLocalMapper.kt
+++ b/data/src/main/java/com/london/data/mapper/home/toprated/TopRatedMediaLocalMapper.kt
@@ -1,28 +1,25 @@
 package com.london.data.mapper.home.toprated
 
 import com.london.data.local.model.home.topRated.TopRatedLocal
-import com.london.data.utils.asImageUrlOrEmpty
-import com.london.data.utils.orZero
-import com.london.domain.entity.recent.MediaType
 import com.london.domain.entity.toprated.TopRatedMedia
 
 fun TopRatedLocal.toEntity(): TopRatedMedia =
     TopRatedMedia(
-        id = id.orZero(),
-        posterUrl = posterPictureUrl.asImageUrlOrEmpty(),
-        releaseDate = releaseYear,
+        id = id,
         name = name,
-        voteAverage = rating.orZero(),
         genreIds = genre,
-        mediaType = mediaType
+        voteAverage = rating,
+        mediaType = mediaType,
+        releaseDate = releaseYear,
+        posterUrl = posterPictureUrl,
     )
 fun TopRatedMedia.toLocal(): TopRatedLocal =
     TopRatedLocal(
         id = id,
         name = name,
-        posterPictureUrl = posterUrl,
+        genre = genreIds,
         rating = voteAverage,
+        mediaType = mediaType,
         releaseYear = releaseDate,
-        mediaType = MediaType.TvShow,
-        genre = genreIds
+        posterPictureUrl = posterUrl,
     )


### PR DESCRIPTION
# What does this PR do?

This fixes an issue where the top rated section where movies are duplicated, root issue was default mapping to `mediaType = MediaType.TvShow`, modified it to accept incoming.