### PR TITLE
refactor: Move DI modules from data to app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,4 +108,8 @@ dependencies {
 
     ksp(libs.bundles.hilt.ksp)
     implementation(libs.bundles.hilt.runtime)
+
+    implementation(libs.bundles.retrofit)
+    implementation(libs.retrofit2.kotlinx.serialization.converter)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/app/src/main/java/com/london/app/di/DataBaseModule.kt
+++ b/app/src/main/java/com/london/app/di/DataBaseModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import android.content.Context
 import androidx.room.Room

--- a/app/src/main/java/com/london/app/di/DataModule.kt
+++ b/app/src/main/java/com/london/app/di/DataModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import android.content.Context
 import android.content.SharedPreferences

--- a/app/src/main/java/com/london/app/di/LocalDataSourceModule.kt
+++ b/app/src/main/java/com/london/app/di/LocalDataSourceModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import android.content.SharedPreferences
 import com.london.data.local.database.dao.customLists.ListMembershipDao

--- a/app/src/main/java/com/london/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/london/app/di/NetworkModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import android.content.Context
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory

--- a/app/src/main/java/com/london/app/di/RemoteDataSourceModule.kt
+++ b/app/src/main/java/com/london/app/di/RemoteDataSourceModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import com.london.data.remote.service.account.AccountApiService
 import com.london.data.remote.service.actor.ActorApiService

--- a/app/src/main/java/com/london/app/di/RepositoryModule.kt
+++ b/app/src/main/java/com/london/app/di/RepositoryModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import com.london.data.local.database.dao.search.GenreInterestDao
 import com.london.data.local.model.home.popular.PopularSectionLocal

--- a/app/src/main/java/com/london/app/di/WorkerModule.kt
+++ b/app/src/main/java/com/london/app/di/WorkerModule.kt
@@ -1,4 +1,4 @@
-package com.london.data.di
+package com.london.app.di
 
 import android.content.Context
 import androidx.work.WorkManager


### PR DESCRIPTION
# What does this PR do?

This PR moves the following Dagger Hilt modules from the `data` module to the `app` module:
- `RepositoryModule`
- `RemoteDataSourceModule`
- `NetworkModule`
- `DataModule`
- `WorkerModule`
- `LocalDataSourceModule`
- `DataBaseModule`

Additionally, it adds Retrofit and Kotlinx Serialization dependencies to the `app/build.gradle.kts` file.

## Type of Change
- [x] 🔧 Refactoring

## Changes Made
- [x] Data


## Checklist
- [x] Ready for review
