### PR TITLE
Refactor: add home sections to home screen as private functions

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -11,12 +11,16 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -42,12 +46,17 @@ import com.london.designsystem.component.button.PrimaryButton
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.string
 import com.london.domain.entity.UpComingMovie
+import com.london.domain.entity.recent.MediaType
 import com.london.presentation.R
-import com.london.presentation.feature.home.continuewatching.continueWatchingSection
-import com.london.presentation.feature.home.popular.popularSection
-import com.london.presentation.feature.home.toprated.topRatedSection
-import com.london.presentation.feature.home.trending.trendingSection
-import com.london.presentation.feature.home.upcoming.upcomingSection
+import com.london.presentation.feature.home.popular.PopularSection
+import com.london.presentation.feature.home.section.ContinueWatchingSection
+import com.london.presentation.feature.home.section.ShimmerPopularSection
+import com.london.presentation.feature.home.section.TopRatedSection
+import com.london.presentation.feature.home.trending.TrendingSection
+import com.london.presentation.feature.home.upcoming.UpcomingMovieItem
+import com.london.presentation.feature.home.upcoming.UpcomingSectionTitle
+import com.london.presentation.feature.home.upcoming.UpcomingStickyHeader
+import com.london.presentation.shared.CarousalShimmerEffect
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
 import com.london.presentation.shared.buildscreen.NetworkErrorScreen
 import com.london.presentation.utils.Listen
@@ -118,7 +127,7 @@ private fun HandleScreenState(
     uiState: HomeScreenUiState,
     screenDimensions: ScreenDimensions,
     lazyGridState: LazyGridState,
-    pagerState: androidx.compose.foundation.pager.PagerState,
+    pagerState: PagerState,
     recentWatchedMedia: List<HomeUiMedia>,
     upcomingMoviesLazyList: LazyPagingItems<UpComingMovie>,
     scrollState: ScrollState,
@@ -133,6 +142,7 @@ private fun HandleScreenState(
                 }
             )
         }
+
         else -> {
             HomeScreenLayout(
                 modifier = Modifier,
@@ -165,7 +175,7 @@ private fun HomeScreenLayout(
     screenWidth: Dp,
     lazyGridState: LazyGridState,
     uiState: HomeScreenUiState,
-    pagerState: androidx.compose.foundation.pager.PagerState,
+    pagerState: PagerState,
     recentWatchedMedia: List<HomeUiMedia>,
     upcomingMoviesLazyList: LazyPagingItems<UpComingMovie>,
     scrollState: ScrollState,
@@ -256,7 +266,7 @@ private fun HomeContentGrid(
     lazyGridState: LazyGridState,
     screenWidth: Dp,
     uiState: HomeScreenUiState,
-    pagerState: androidx.compose.foundation.pager.PagerState,
+    pagerState: PagerState,
     recentWatchedMedia: List<HomeUiMedia>,
     upcomingMoviesLazyList: LazyPagingItems<UpComingMovie>,
     scrollState: ScrollState,
@@ -315,6 +325,122 @@ private fun HomeContentGrid(
     }
 }
 
+private fun LazyGridScope.popularSection(
+    screenWidth: Dp,
+    uiState: HomeScreenUiState,
+    pagerState: PagerState,
+    homeScreenContract: HomeScreenContract
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        if (uiState.popularMediaList.isNotEmpty()) {
+            PopularSection(
+                modifier = Modifier.requiredWidth(screenWidth),
+                pagerState = pagerState,
+                uiMediaList = uiState.popularMediaList,
+                onManageBookmarkClicked = { movieId ->
+                    homeScreenContract.onManageBookmarkClicked(movieId)
+                },
+                onCardClick = { id, mediaType ->
+                    when (mediaType) {
+                        MediaType.TvShow -> homeScreenContract.onTvShowClick(id)
+                        MediaType.Movie -> homeScreenContract.onMovieClick(id)
+                    }
+                }
+            )
+        } else {
+            ShimmerPopularSection(
+                modifier = Modifier.requiredWidth(screenWidth),
+                pagerState = pagerState,
+            )
+        }
+    }
+}
+
+private fun LazyGridScope.trendingSection(
+    isLoading: Boolean,
+    homeScreenContract: HomeScreenContract
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        TrendingSection(
+            isLoading = isLoading,
+            onMoviesClick = homeScreenContract::onTrendingMoviesCardClick,
+            onTvShowsClick = homeScreenContract::onTrendingTvShowsCardClick,
+            onActorsClick = homeScreenContract::onTrendingActorsCardClick
+        )
+    }
+}
+
+private fun LazyGridScope.topRatedSection(
+    screenWidth: Dp,
+    uiState: HomeScreenUiState,
+    homeScreenContract: HomeScreenContract
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        if (!uiState.isTopRatedLoading) {
+            TopRatedSection(
+                uiState = uiState,
+                homeScreenContract = homeScreenContract,
+                modifier = Modifier.requiredWidth(screenWidth)
+            )
+        } else {
+            CarousalShimmerEffect()
+        }
+    }
+}
+
+private fun LazyGridScope.continueWatchingSection(
+    screenWidth: Dp,
+    recentWatchedMedia: List<HomeUiMedia>,
+    isLoading: Boolean,
+    homeScreenContract: HomeScreenContract
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        if (!isLoading) {
+            ContinueWatchingSection(
+                recentWatchedMediaList = recentWatchedMedia,
+                homeScreenContract = homeScreenContract,
+                modifier = Modifier.requiredWidth(screenWidth)
+            )
+        } else {
+            CarousalShimmerEffect()
+        }
+    }
+}
+
+private fun LazyGridScope.upcomingSection(
+    contract: HomeScreenContract,
+    isHeaderStuck: Boolean = false,
+    screenWidth: Dp,
+    state: HomeScreenUiState,
+    upcomingMoviesLazyList: LazyPagingItems<UpComingMovie>,
+    isLoading: Boolean = false
+) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
+        UpcomingSectionTitle(isLoading = isLoading)
+    }
+
+    stickyHeader {
+        UpcomingStickyHeader(
+            isLoading = isLoading,
+            isHeaderStuck = isHeaderStuck,
+            screenWidth = screenWidth,
+            state = state,
+            contract = contract
+        )
+    }
+
+    items(count = upcomingMoviesLazyList.itemCount) { index ->
+        val movie = upcomingMoviesLazyList[index]
+
+        UpcomingMovieItem(
+            movie = movie,
+            isLoading = isLoading,
+            onMovieClick = { contract.onMovieClick(movie?.id ?: 0) },
+            onManageBookmarkClick = contract::onManageBookmarkClicked
+        )
+    }
+}
+
 @Composable
 private fun FloatingRetryButton(
     onRetry: () -> Unit,
@@ -333,7 +459,6 @@ private fun FloatingRetryButton(
             .width(52.dp)
     )
 }
-
 
 @Composable
 private fun rememberScreenDimensions(): ScreenDimensions {
@@ -359,7 +484,9 @@ private fun rememberScrollState(
     lazyGridState: LazyGridState,
     uiState: HomeScreenUiState
 ): ScrollState {
-    val recentWatchedMediaFlow by uiState.recentWatchedMediaFlow.collectAsStateWithLifecycle(emptyList())
+    val recentWatchedMediaFlow by uiState.recentWatchedMediaFlow.collectAsStateWithLifecycle(
+        emptyList()
+    )
 
     val isAtEndOfGrid by remember {
         derivedStateOf {

--- a/presentation/src/main/java/com/london/presentation/feature/home/continuewatching/ContinueWatchingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/continuewatching/ContinueWatchingScreen.kt
@@ -33,25 +33,6 @@ import com.london.presentation.shared.container.MediaGridConfig
 import com.london.presentation.shared.container.MediaLazyGridWithTabs
 import com.london.presentation.utils.Listen
 
-fun LazyGridScope.continueWatchingSection(
-    screenWidth: Dp,
-    recentWatchedMedia: List<HomeUiMedia>,
-    isLoading: Boolean,
-    homeScreenContract: HomeScreenContract
-) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
-        if (!isLoading) {
-            ContinueWatchingSection(
-                recentWatchedMediaList = recentWatchedMedia,
-                homeScreenContract = homeScreenContract,
-                modifier = Modifier.requiredWidth(screenWidth)
-            )
-        } else {
-            CarousalShimmerEffect()
-        }
-    }
-}
-
 @Composable
 fun ContinueWatchingScreen(
     screenTitle: String,

--- a/presentation/src/main/java/com/london/presentation/feature/home/popular/PopularSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/popular/PopularSection.kt
@@ -10,10 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -28,7 +25,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
@@ -38,8 +34,6 @@ import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.recent.MediaType
 import com.london.domain.entity.recent.MediaType.Companion.isMovie
 import com.london.presentation.R
-import com.london.presentation.feature.home.HomeScreenContract
-import com.london.presentation.feature.home.HomeScreenUiState
 import com.london.presentation.feature.home.popular.PopularSection.CARD_HORIZONTAL_PADDING_DP
 import com.london.presentation.feature.home.popular.PopularSection.CARD_WIDTH_DP
 import com.london.presentation.feature.home.popular.PopularSection.PAGE_SPACING_DP
@@ -53,7 +47,6 @@ import com.london.presentation.feature.home.popular.PopularSection.SCALE_MIN_FRA
 import com.london.presentation.feature.home.popular.PopularSection.SCALE_SIDE_CARDS
 import com.london.presentation.feature.home.popular.PopularSection.TRANSFORM_ORIGIN_X
 import com.london.presentation.feature.home.popular.PopularSection.TRANSFORM_ORIGIN_Y
-import com.london.presentation.feature.home.section.ShimmerPopularSection
 import com.london.presentation.shared.HomeCard
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.utils.toLocalizedNumbers
@@ -62,40 +55,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlin.math.abs
 
-fun LazyGridScope.popularSection(
-    screenWidth: Dp,
-    uiState: HomeScreenUiState,
-    pagerState: PagerState,
-    homeScreenContract: HomeScreenContract
-) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
-        if (uiState.popularMediaList.isNotEmpty()) {
-            PopularSection(
-                modifier = Modifier.requiredWidth(screenWidth),
-                pagerState = pagerState,
-                uiMediaList = uiState.popularMediaList,
-                onManageBookmarkClicked = { movieId ->
-                    homeScreenContract.onManageBookmarkClicked(movieId)
-                },
-                onCardClick = { id, mediaType ->
-                    when (mediaType) {
-                        MediaType.TvShow -> homeScreenContract.onTvShowClick(id)
-                        MediaType.Movie -> homeScreenContract.onMovieClick(id)
-                    }
-                }
-            )
-        } else {
-            ShimmerPopularSection(
-                modifier = Modifier.requiredWidth(screenWidth),
-                pagerState = pagerState,
-            )
-        }
-    }
-}
-
-
 @Composable
-private fun PopularSection(
+fun PopularSection(
     pagerState: PagerState,
     uiMediaList: List<PopularUiMedia>,
     onCardClick: (Int, MediaType) -> Unit,

--- a/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
@@ -15,8 +15,6 @@ import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -37,10 +35,6 @@ import com.london.designsystem.component.TabLayout
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.string
-import com.london.presentation.feature.home.HomeScreenContract
-import com.london.presentation.feature.home.HomeScreenUiState
-import com.london.presentation.feature.home.section.TopRatedSection
-import com.london.presentation.shared.CarousalShimmerEffect
 import com.london.presentation.shared.HomeCard
 import com.london.presentation.shared.MediaCategory
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -49,24 +43,6 @@ import com.london.presentation.shared.genre.TvShowGenreUi
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.gridColumns
 import com.london.presentation.utils.isLoading
-
-fun LazyGridScope.topRatedSection(
-    screenWidth: Dp,
-    uiState: HomeScreenUiState,
-    homeScreenContract: HomeScreenContract
-) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
-        if (!uiState.isTopRatedLoading) {
-            TopRatedSection(
-                uiState = uiState,
-                homeScreenContract = homeScreenContract,
-                modifier = Modifier.requiredWidth(screenWidth)
-            )
-        } else {
-            CarousalShimmerEffect()
-        }
-    }
-}
 
 @Composable
 fun TopRatedScreen(

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/TrendingSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/TrendingSection.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -39,24 +37,9 @@ import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.noRippleClickable
 import com.london.designsystem.utils.shimmerEffect
 import com.london.presentation.R
-import com.london.presentation.feature.home.HomeScreenContract
-
-fun LazyGridScope.trendingSection(
-    isLoading: Boolean,
-    homeScreenContract: HomeScreenContract
-) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
-        TrendingSection(
-            isLoading = isLoading,
-            onMoviesClick = homeScreenContract::onTrendingMoviesCardClick,
-            onTvShowsClick = homeScreenContract::onTrendingTvShowsCardClick,
-            onActorsClick = homeScreenContract::onTrendingActorsCardClick
-        )
-    }
-}
 
 @Composable
-private fun TrendingSection(
+fun TrendingSection(
     onMoviesClick: () -> Unit,
     onTvShowsClick: () -> Unit,
     onActorsClick: () -> Unit,

--- a/presentation/src/main/java/com/london/presentation/feature/home/upcoming/upcomingSection.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/upcoming/upcomingSection.kt
@@ -9,8 +9,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,7 +18,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.paging.compose.LazyPagingItems
 import com.london.designsystem.component.Text
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.shimmerEffect
@@ -31,42 +28,8 @@ import com.london.presentation.feature.home.HomeScreenUiState
 import com.london.presentation.shared.GenresSection
 import com.london.presentation.shared.HomeCard
 
-fun LazyGridScope.upcomingSection(
-    contract: HomeScreenContract,
-    isHeaderStuck: Boolean = false,
-    screenWidth: Dp,
-    state: HomeScreenUiState,
-    upcomingMoviesLazyList: LazyPagingItems<UpComingMovie>,
-    isLoading: Boolean = false
-) {
-    item(span = { GridItemSpan(maxLineSpan) }) {
-        UpcomingSectionTitle(isLoading = isLoading)
-    }
-
-    stickyHeader {
-        UpcomingStickyHeader(
-            isLoading = isLoading,
-            isHeaderStuck = isHeaderStuck,
-            screenWidth = screenWidth,
-            state = state,
-            contract = contract
-        )
-    }
-
-    items(count = upcomingMoviesLazyList.itemCount) { index ->
-        val movie = upcomingMoviesLazyList[index]
-
-        UpcomingMovieItem(
-            movie = movie,
-            isLoading = isLoading,
-            onMovieClick = { contract.onMovieClick(movie?.id ?: 0) },
-            onManageBookmarkClick = contract::onManageBookmarkClicked
-        )
-    }
-}
-
 @Composable
-private fun UpcomingSectionTitle(isLoading: Boolean) {
+fun UpcomingSectionTitle(isLoading: Boolean) {
     if (!isLoading) {
         Text(
             text = stringResource(R.string.upcoming),
@@ -85,7 +48,7 @@ private fun UpcomingSectionTitle(isLoading: Boolean) {
 }
 
 @Composable
-private fun UpcomingStickyHeader(
+fun UpcomingStickyHeader(
     isLoading: Boolean,
     isHeaderStuck: Boolean,
     screenWidth: Dp,
@@ -115,7 +78,7 @@ private fun UpcomingStickyHeader(
 }
 
 @Composable
-private fun UpcomingMovieItem(
+fun UpcomingMovieItem(
     movie: UpComingMovie?,
     isLoading: Boolean,
     onMovieClick: () -> Unit,


### PR DESCRIPTION
# What does this PR do?

This PR extracts the `popularSection`, `trendingSection`, `topRatedSection`, `continueWatchingSection`, and `upcomingSection` from the `HomeScreen` composable into their own respective functions. This improves the readability and organization of the `HomeScreen` code.

## Type of Change
- [x] 🔧 Refactoring

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
