### PR TITLE
fix: Rename HomeScreenEffect navigation classes

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -78,13 +78,13 @@ fun HomeScreen(
 
     effect?.Listen { currentEffect ->
         when (currentEffect) {
-            is HomeScreenEffect.NavigationMovieDetails -> onNavigateToMovieDetails(currentEffect.id)
-            is HomeScreenEffect.NavigationTvShowDetails -> onNavigateToTvShowDetails(currentEffect.id)
-            is HomeScreenEffect.NavigationTrendingMovie -> onNavigateToTrendingMovies()
-            is HomeScreenEffect.NavigationTrendingTvShows -> onNavigateToTrendingTvShows()
-            is HomeScreenEffect.NavigationTrendingActor -> onNavigateToTrendingActors()
-            is HomeScreenEffect.NavigationTopRated -> onNavigateToTopRated()
-            is HomeScreenEffect.NavigationContinueWatching -> onNavigateToContinueWatching()
+            is HomeScreenEffect.MovieDetailsNavigation -> onNavigateToMovieDetails(currentEffect.id)
+            is HomeScreenEffect.TvShowDetailsNavigation -> onNavigateToTvShowDetails(currentEffect.id)
+            is HomeScreenEffect.TrendingMovieNavigation -> onNavigateToTrendingMovies()
+            is HomeScreenEffect.TrendingTvShowsNavigation -> onNavigateToTrendingTvShows()
+            is HomeScreenEffect.TrendingActorNavigation -> onNavigateToTrendingActors()
+            is HomeScreenEffect.TopRatedNavigation -> onNavigateToTopRated()
+            is HomeScreenEffect.ContinueWatchingNavigation -> onNavigateToContinueWatching()
         }
     }
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenEffect.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreenEffect.kt
@@ -1,11 +1,11 @@
 package com.london.presentation.feature.home
 
 interface HomeScreenEffect {
-    object NavigationTopRated : HomeScreenEffect
-    object NavigationTrendingActor : HomeScreenEffect
-    object NavigationTrendingMovie : HomeScreenEffect
-    object NavigationTrendingTvShows : HomeScreenEffect
-    object NavigationContinueWatching : HomeScreenEffect
-    data class NavigationTvShowDetails(val id: Int) : HomeScreenEffect
-    data class NavigationMovieDetails(val id: Int) : HomeScreenEffect
+    object TopRatedNavigation : HomeScreenEffect
+    object TrendingActorNavigation : HomeScreenEffect
+    object TrendingMovieNavigation : HomeScreenEffect
+    object TrendingTvShowsNavigation : HomeScreenEffect
+    object ContinueWatchingNavigation : HomeScreenEffect
+    data class TvShowDetailsNavigation(val id: Int) : HomeScreenEffect
+    data class MovieDetailsNavigation(val id: Int) : HomeScreenEffect
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeViewModel.kt
@@ -172,10 +172,10 @@ class HomeViewModel @Inject constructor(
     }
 
     override fun onMovieClick(id: Int) =
-        emitEffect(HomeScreenEffect.NavigationMovieDetails(id))
+        emitEffect(HomeScreenEffect.MovieDetailsNavigation(id))
 
     override fun onTvShowClick(id: Int) =
-        emitEffect(HomeScreenEffect.NavigationTvShowDetails(id))
+        emitEffect(HomeScreenEffect.TvShowDetailsNavigation(id))
 
     override fun onMovieGenreSelect(genre: MovieGenreUi) {
         if (genre == state.value.selectedMovieGenre) return
@@ -184,17 +184,17 @@ class HomeViewModel @Inject constructor(
     }
 
     override fun onTopRatedClick() =
-        emitEffect(HomeScreenEffect.NavigationTopRated)
+        emitEffect(HomeScreenEffect.TopRatedNavigation)
 
     override fun onContinueWatchingClick() =
-        emitEffect(HomeScreenEffect.NavigationContinueWatching)
+        emitEffect(HomeScreenEffect.ContinueWatchingNavigation)
 
     override fun onTrendingMoviesCardClick() =
-        emitEffect(HomeScreenEffect.NavigationTrendingMovie)
+        emitEffect(HomeScreenEffect.TrendingMovieNavigation)
 
     override fun onTrendingTvShowsCardClick() =
-        emitEffect(HomeScreenEffect.NavigationTrendingTvShows)
+        emitEffect(HomeScreenEffect.TrendingTvShowsNavigation)
 
     override fun onTrendingActorsCardClick() =
-        emitEffect(HomeScreenEffect.NavigationTrendingActor)
+        emitEffect(HomeScreenEffect.TrendingActorNavigation)
 }

--- a/presentation/src/test/java/com/london/presentation/feature/home/HomeViewModelTest.kt
+++ b/presentation/src/test/java/com/london/presentation/feature/home/HomeViewModelTest.kt
@@ -205,7 +205,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onMovieClick(movieId)
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationMovieDetails::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.MovieDetailsNavigation::class.java)
         }
     }
 
@@ -218,7 +218,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onTvShowClick(tvShowId)
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationTvShowDetails::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.TvShowDetailsNavigation::class.java)
         }
     }
 
@@ -229,7 +229,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onTopRatedClick()
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationTopRated::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.TopRatedNavigation::class.java)
         }
     }
 
@@ -240,7 +240,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onContinueWatchingClick()
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationContinueWatching::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.ContinueWatchingNavigation::class.java)
         }
     }
 
@@ -251,7 +251,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onTrendingMoviesCardClick()
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationTrendingMovie::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.TrendingMovieNavigation::class.java)
         }
     }
 
@@ -262,7 +262,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onTrendingTvShowsCardClick()
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationTrendingTvShows::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.TrendingTvShowsNavigation::class.java)
         }
     }
 
@@ -273,7 +273,7 @@ class HomeViewModelTest {
         viewModel.effect.test {
             viewModel.onTrendingActorsCardClick()
             val effect = awaitItem()
-            assertThat(effect).isInstanceOf(HomeScreenEffect.NavigationTrendingActor::class.java)
+            assertThat(effect).isInstanceOf(HomeScreenEffect.TrendingActorNavigation::class.java)
         }
     }
 


### PR DESCRIPTION
# What does this PR do?
<!-- Brief description of changes -->
This change is applied consistently across:
- `HomeScreenEffect.kt` (definitions)
- `HomeViewModel.kt` (emission of effects)
- `HomeScreen.kt` (handling of effects)
- `HomeViewModelTest.kt` (assertions in unit tests)