### PR TITLE
refactor: Update `TextWithIcon` composable to support tint color and init dot

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
@@ -137,7 +137,7 @@ private fun Content(
     val shouldShowBackground by remember {
         derivedStateOf {
             lazyState.firstVisibleItemScrollOffset > 40f ||
-                    lazyState.firstVisibleItemIndex > 0
+                lazyState.firstVisibleItemIndex > 0
         }
     }
 
@@ -388,6 +388,8 @@ private fun RatingAndMetaRow(
             TextWithIcon(
                 text = rate.toLocalizedNumbers(),
                 icon = painterResource(drawable.star),
+                tint = NovixTheme.colors.yellowAccent,
+                hasInitialDot = false
             )
         }
 
@@ -402,8 +404,7 @@ private fun RatingAndMetaRow(
             TextWithIcon(
                 icon = painterResource(drawable.time_04),
                 text = text,
-
-                )
+            )
 
             if (!date.isNullOrBlank()) {
                 TextWithIcon(

--- a/presentation/src/main/java/com/london/presentation/shared/TextWithIcon.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/TextWithIcon.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
@@ -23,7 +24,9 @@ import com.london.presentation.R
 @Composable
 fun TextWithIcon(
     text: String,
-    icon: Painter
+    icon: Painter,
+    tint: Color = NovixTheme.colors.body,
+    hasInitialDot: Boolean = true
 ) {
     if (text.isEmpty()) return
     Row(
@@ -33,18 +36,20 @@ fun TextWithIcon(
         val scale = LocalDensity.current.fontScale
         val baseIconSize = 12.dp
 
-        Box(
-            modifier = Modifier
-                .padding(4.dp)
-                .size(3.dp)
-                .clip(CircleShape)
-                .background(NovixTheme.colors.body)
-                .align(alignment = Alignment.CenterVertically)
-        )
+        if (hasInitialDot)
+            Box(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(3.dp)
+                    .clip(CircleShape)
+                    .background(NovixTheme.colors.body)
+                    .align(alignment = Alignment.CenterVertically)
+            )
+        
         Icon(
             painter = icon,
             contentDescription = stringResource(R.string.image_dot),
-            tint = NovixTheme.colors.body,
+            tint = tint,
             modifier = Modifier.size(baseIconSize * scale)
         )
         Text(


### PR DESCRIPTION
# What does this PR do?

The `TextWithIcon` composable has been updated to accept two new optional parameters: `tint` for specifying the icon color and `hasInitialDot` for controlling the visibility of the initial dot.

The `MovieDetailsScreen` has been updated to utilize these new parameters, specifically setting the star icon's tint to yellow and removing the initial dot for the rating display.

## Type of Change
- [x] 🐛 Bug fix
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Screenshots
<img width="436" height="815" alt="image" src="https://github.com/user-attachments/assets/c37678a2-edf5-4aa0-b9e3-04f1925c7b05" />

## Checklist
- [ ] Code builds without warnings
- [ ] Self-reviewed
- [ ] Tests pass
- [x] Ready for review
