### PR TITLE
Hotfix/edge2edge

### DIFF
--- a/app/src/main/java/com/london/app/MainActivity.kt
+++ b/app/src/main/java/com/london/app/MainActivity.kt
@@ -2,7 +2,6 @@ package com.london.app
 
 import android.app.Activity
 import android.content.Context
-import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -16,9 +15,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
-import androidx.core.graphics.toColorInt
-import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.london.app.navigation.NavHostGraph
 import com.london.data.local.preference.readLanguageCode
@@ -48,12 +47,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         enableEdgeToEdge()
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            window.isNavigationBarContrastEnforced = false
-        }
 
         setContent {
             val isAppDarkMode by appPreferencesService.isAppDarkMode.collectAsState()
@@ -90,8 +84,6 @@ private fun ApplySystemBarTheme(useDarkTheme: Boolean) {
     val view = LocalView.current
     if (view.isInEditMode) return
 
-    val translucentScrimColor = "#00000000".toColorInt()
-
     LaunchedEffect(useDarkTheme) {
         val window = (view.context as Activity).window
         val insetsController = WindowInsetsControllerCompat(window, view)
@@ -100,10 +92,10 @@ private fun ApplySystemBarTheme(useDarkTheme: Boolean) {
         insetsController.isAppearanceLightNavigationBars = !useDarkTheme
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            window.navigationBarColor = Color.TRANSPARENT
+            window.navigationBarColor = Color.Transparent.toArgb()
             window.isNavigationBarContrastEnforced = false
         } else {
-            window.navigationBarColor = translucentScrimColor
+            window.navigationBarColor = Color.Transparent.toArgb()
         }
     }
 }

--- a/app/src/main/java/com/london/app/navigation/NavHostGraph.kt
+++ b/app/src/main/java/com/london/app/navigation/NavHostGraph.kt
@@ -4,8 +4,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -44,10 +44,10 @@ fun NavHostGraph() {
     }
 
     val showBottomNav = navBackStackEntry.hasRoute(Home) ||
-            navBackStackEntry.hasRoute(Search) ||
-            navBackStackEntry.hasRoute(Categories) ||
-            navBackStackEntry.hasRoute(Lists()) ||
-            navBackStackEntry.hasRoute(Account)
+        navBackStackEntry.hasRoute(Search) ||
+        navBackStackEntry.hasRoute(Categories) ||
+        navBackStackEntry.hasRoute(Lists()) ||
+        navBackStackEntry.hasRoute(Account)
 
     Scaffold(
         containerColor = NovixTheme.colors.surface,
@@ -72,7 +72,7 @@ fun NavHostGraph() {
             NavHost(
                 navController = navController,
                 startDestination = AppNavGraph.Splash,
-                modifier = Modifier.padding(innerPadding)
+                modifier = Modifier.consumeWindowInsets(innerPadding)
             ) {
                 onboardingNavGraph(navController)
                 splashNavGraph(navController)

--- a/app/src/main/java/com/london/app/navigation/NavHostGraph.kt
+++ b/app/src/main/java/com/london/app/navigation/NavHostGraph.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
@@ -58,7 +57,6 @@ fun NavHostGraph() {
                 exit = slideOutVertically(animationSpec = tween(), targetOffsetY = { it })
             ) {
                 NavBar(
-                    modifier = Modifier.navigationBarsPadding(),
                     navDestinations = NavigationHelper.getNavigationTabs(),
                     currentSelectedDestination = currentScreen,
                     onNavDestinationClicked = { destination ->

--- a/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -43,6 +44,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.london.designsystem.R
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.ThemePreviews
@@ -82,6 +84,7 @@ fun <T> NavBar(
             .fillMaxWidth()
             .topBorder(navBarColors.topBorderColor, 1.dp)
             .background(color = navBarColors.backgroundColor)
+            .navigationBarsPadding()
             .padding(vertical = 7.dp),
         horizontalArrangement = Arrangement.SpaceEvenly,
         verticalAlignment = Alignment.CenterVertically

--- a/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/AppNavBar.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import com.london.designsystem.R
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.ThemePreviews
@@ -79,26 +78,35 @@ fun <T> NavBar(
     )
 ) {
 
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .topBorder(navBarColors.topBorderColor, 1.dp)
             .background(color = navBarColors.backgroundColor)
             .navigationBarsPadding()
-            .padding(vertical = 7.dp),
-        horizontalArrangement = Arrangement.SpaceEvenly,
-        verticalAlignment = Alignment.CenterVertically
+            .clickable(
+                enabled = false,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }) {}
     ) {
-        navDestinations.forEach { item ->
-            NavBarItem(
-                item = item,
-                isSelected = currentSelectedDestination == item.destination,
-                selectedIconColor = navBarColors.selectedIconColor,
-                idleIconColor = navBarColors.idleIconColor,
-                onClick = {
-                    onNavDestinationClicked(item.destination)
-                }
-            )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .topBorder(navBarColors.topBorderColor, 1.dp)
+                .padding(vertical = 7.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            navDestinations.forEach { item ->
+                NavBarItem(
+                    item = item,
+                    isSelected = currentSelectedDestination == item.destination,
+                    selectedIconColor = navBarColors.selectedIconColor,
+                    idleIconColor = navBarColors.idleIconColor,
+                    onClick = {
+                        onNavDestinationClicked(item.destination)
+                    }
+                )
+            }
         }
     }
 }

--- a/designSystem/src/main/java/com/london/designsystem/component/TopBar.kt
+++ b/designSystem/src/main/java/com/london/designsystem/component/TopBar.kt
@@ -7,9 +7,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -40,6 +43,7 @@ fun TopBar(
     Row(
         modifier = modifier
             .fillMaxWidth()
+            .padding(WindowInsets.statusBars.asPaddingValues())
             .padding(top = 12.dp)
             .zIndex(1f),
         verticalAlignment = Alignment.CenterVertically,

--- a/presentation/src/main/java/com/london/presentation/feature/authentication/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/authentication/login/LoginScreen.kt
@@ -9,8 +9,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -79,7 +82,8 @@ private fun Content(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(NovixTheme.colors.surface),
+            .background(NovixTheme.colors.surface)
+            .padding(WindowInsets.navigationBars.asPaddingValues()),
     ) {
         Image(
             painter = painterResource(dsR.drawable.polygon1),

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
@@ -58,6 +58,7 @@ import com.london.presentation.shared.ImageView
 import com.london.presentation.shared.TextWithIcon
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.detailsTopBar
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.toLocalizedNumbers
 
@@ -173,9 +174,7 @@ private fun Content(
         TopBar(
             onBackClick = actorDetailsContract::onBackClick,
             modifier = Modifier
-                .fillMaxWidth()
-                .background(NovixTheme.colors.surface.copy(alpha = backgroundAlpha))
-                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .detailsTopBar(backgroundAlpha)
                 .zIndex(1f)
         )
     }
@@ -415,13 +414,13 @@ private fun EmptyScreen(uiState: ActorDetailsUiState) {
     if (uiState.isLoading || uiState.error != null) return
 
     val hasNoContent = uiState.actorImageDetails.isNullOrEmpty() &&
-            uiState.actorMovieDetails?.mediaItems.isNullOrEmpty() &&
-            uiState.actorTvShowDetails?.mediaItems.isNullOrEmpty() &&
-            uiState.actorDetails.biography.isBlank() &&
-            (uiState.actorDetails.name.isBlank() &&
-                    uiState.actorDetails.birthday.isBlank() &&
-                    uiState.actorDetails.placeOfBirth.isBlank() &&
-                    uiState.actorDetails.knownForDepartment.isBlank())
+        uiState.actorMovieDetails?.mediaItems.isNullOrEmpty() &&
+        uiState.actorTvShowDetails?.mediaItems.isNullOrEmpty() &&
+        uiState.actorDetails.biography.isBlank() &&
+        (uiState.actorDetails.name.isBlank() &&
+            uiState.actorDetails.birthday.isBlank() &&
+            uiState.actorDetails.placeOfBirth.isBlank() &&
+            uiState.actorDetails.knownForDepartment.isBlank())
 
     if (hasNoContent) {
         EmptyLayout(
@@ -434,12 +433,12 @@ private fun EmptyScreen(uiState: ActorDetailsUiState) {
 
 private fun hasOtherContent(uiState: ActorDetailsUiState): Boolean {
     return uiState.actorDetails.name.isNotBlank() ||
-            uiState.actorDetails.birthday.isNotBlank() ||
-            uiState.actorDetails.placeOfBirth.isNotBlank() ||
-            uiState.actorDetails.knownForDepartment.isNotBlank() ||
-            uiState.actorDetails.biography.isNotBlank() ||
-            !uiState.actorMovieDetails?.mediaItems.isNullOrEmpty() ||
-            !uiState.actorTvShowDetails?.mediaItems.isNullOrEmpty()
+        uiState.actorDetails.birthday.isNotBlank() ||
+        uiState.actorDetails.placeOfBirth.isNotBlank() ||
+        uiState.actorDetails.knownForDepartment.isNotBlank() ||
+        uiState.actorDetails.biography.isNotBlank() ||
+        !uiState.actorMovieDetails?.mediaItems.isNullOrEmpty() ||
+        !uiState.actorTvShowDetails?.mediaItems.isNullOrEmpty()
 }
 
 @Preview

--- a/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
@@ -72,6 +72,7 @@ import com.london.presentation.shared.TextWithIcon
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.shared.genre.MovieGenreUi
 import com.london.presentation.utils.Listen
+import com.london.presentation.utils.detailsTopBar
 import com.london.presentation.utils.getLocalizedTimeUnit
 import com.london.presentation.utils.gridColumns
 import com.london.presentation.utils.isNotZeroRate
@@ -158,12 +159,7 @@ private fun Content(
 
         TopBar(
             onBackClick = movieDetailsContract::onBackClick,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    NovixTheme.colors.surface.copy(alpha = backgroundAlpha)
-                )
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.detailsTopBar(backgroundAlpha),
             onClickOption1 = { /*todo on click on save*/ },
             option1Icon = R.drawable.icon_remove,
         )

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episode/EpisodeDetailScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episode/EpisodeDetailScreen.kt
@@ -53,7 +53,7 @@ import com.london.presentation.shared.TextWithIcon
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
-import com.london.presentation.utils.episodeTopBar
+import com.london.presentation.utils.detailsTopBar
 import com.london.presentation.utils.headerDetailsCard
 import com.london.presentation.utils.isNotZeroRate
 import com.london.presentation.utils.openUrl
@@ -122,7 +122,7 @@ private fun Content(
     ) {
         TopBar(
             onBackClick = contract::onBackClick,
-            modifier = Modifier.episodeTopBar(backgroundAlpha),
+            modifier = Modifier.detailsTopBar(backgroundAlpha),
             onClickOption1 = { /*todo on click on save*/ },
             option1Icon = Res.drawable.icon_remove,
         )

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
@@ -72,6 +72,7 @@ import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.shared.genre.TvShowGenreUi
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.convertDate
+import com.london.presentation.utils.detailsTopBar
 import com.london.presentation.utils.isNotZeroRate
 import com.london.presentation.utils.offsetLayout
 import com.london.presentation.utils.openUrl
@@ -162,12 +163,7 @@ private fun Content(
     ) {
         TopBar(
             onBackClick = tvShowDetailsContract::onBackClicked,
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    NovixTheme.colors.surface.copy(alpha = backgroundAlpha)
-                )
-                .padding(horizontal = 16.dp, vertical = 8.dp),
+            modifier = Modifier.detailsTopBar(backgroundAlpha),
             onClickOption1 = { /*todo on click on save*/ },
             option1Icon = R.drawable.icon_remove,
         )

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -5,12 +5,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -252,6 +255,7 @@ private fun HomeTopBar(modifier: Modifier = Modifier) {
         appIconContentDescription = R.string.novix_icon.string,
         modifier = modifier
             .background(NovixTheme.colors.surface)
+            .padding(WindowInsets.statusBars.asPaddingValues())
             .padding(top = 12.dp, bottom = 8.dp)
     )
 }

--- a/presentation/src/main/java/com/london/presentation/feature/welcome/onboarding/onboardingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/welcome/onboarding/onboardingScreen.kt
@@ -11,12 +11,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
@@ -69,7 +72,7 @@ fun OnboardingScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(NovixTheme.colors.surface)
-            .systemBarsPadding()
+            .padding(WindowInsets.systemBars.asPaddingValues())
     ) {
         Content(
             pagerState = pagerState,

--- a/presentation/src/main/java/com/london/presentation/feature/welcome/onboarding/welcomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/welcome/onboarding/welcomeScreen.kt
@@ -6,9 +6,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -72,7 +76,8 @@ private fun Content(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(start = 16.dp, end = 16.dp, bottom = 21.dp),
+            .padding(start = 16.dp, end = 16.dp, bottom = 21.dp)
+            .padding(WindowInsets.navigationBars.asPaddingValues()),
         verticalArrangement = Arrangement.Bottom,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/presentation/src/main/java/com/london/presentation/shared/FooterSection.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/FooterSection.kt
@@ -1,11 +1,8 @@
 package com.london.presentation.shared
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -57,11 +54,7 @@ fun FooterSection(
             .padding(WindowInsets.navigationBars.asPaddingValues()),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        AnimatedVisibility(
-            visible = isRateEnabled,
-            enter = slideInHorizontally(tween()),
-            exit = slideOutHorizontally(tween())
-        ) {
+        if (isRateEnabled) {
             PrimaryButton(
                 text = null,
                 onClick = onRateClick,

--- a/presentation/src/main/java/com/london/presentation/shared/FooterSection.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/FooterSection.kt
@@ -1,12 +1,21 @@
 package com.london.presentation.shared
 
-import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -16,15 +25,20 @@ import com.london.designsystem.component.button.PrimaryButton
 import com.london.presentation.R
 import com.london.presentation.R.drawable
 
-@SuppressLint("SuspiciousIndentation")
 @Composable
 fun FooterSection(
     haveTrailer: Boolean,
     modifier: Modifier,
-    isRateEnabled: Boolean = true,
+    isRateEnabled: Boolean,
     onVideoClick: () -> Unit,
     onRateClick: () -> Unit,
 ) {
+    val horizontalPadding by animateDpAsState(
+        targetValue = if (isRateEnabled) 24.dp else 16.dp,
+        label = "footer_horizontal_padding",
+        animationSpec = tween()
+    )
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -38,11 +52,16 @@ fun FooterSection(
                     endY = Float.POSITIVE_INFINITY
                 ),
             )
-            .padding(horizontal = if (haveTrailer) 16.dp else 24.dp)
-            .padding(bottom = 24.dp),
+            .padding(horizontal = horizontalPadding)
+            .padding(bottom = 24.dp)
+            .padding(WindowInsets.navigationBars.asPaddingValues()),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        if (isRateEnabled) {
+        AnimatedVisibility(
+            visible = isRateEnabled,
+            enter = slideInHorizontally(tween()),
+            exit = slideOutHorizontally(tween())
+        ) {
             PrimaryButton(
                 text = null,
                 onClick = onRateClick,
@@ -61,7 +80,9 @@ fun FooterSection(
             isLoading = false,
             enabled = haveTrailer,
             icon = null,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier
+                .weight(1f)
+                .animateContentSize(animationSpec = tween())
         )
     }
 }

--- a/presentation/src/main/java/com/london/presentation/utils/modifierExtensions.kt
+++ b/presentation/src/main/java/com/london/presentation/utils/modifierExtensions.kt
@@ -2,12 +2,9 @@ package com.london.presentation.utils
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -51,7 +48,6 @@ fun Modifier.headerDetailsCard() = fillMaxWidth()
     .background(NovixTheme.colors.surface)
 
 @Composable
-fun Modifier.episodeTopBar(backgroundAlpha: Float) = fillMaxWidth()
+fun Modifier.detailsTopBar(backgroundAlpha: Float) = fillMaxWidth()
     .background(NovixTheme.colors.surface.copy(alpha = backgroundAlpha))
-    .padding(horizontal = 16.dp)
-    .padding(top = WindowInsets.statusBars.asPaddingValues().calculateTopPadding() + 12.dp)
+    .padding(horizontal = 16.dp, vertical = 8.dp)


### PR DESCRIPTION
## Hotfix: Edge 2 Edge with Material 3 Scaffold

### Changes
- **System Bar Handling**: 
  - Removed deprecated `WindowCompat.setDecorFitsSystemWindows` and simplified edge-to-edge implementation
  - Migrated from Android framework `Color` to Compose `Color` for system bar theming
  - Standardized transparent navigation bar color handling across API levels

- **Navigation Bar**:
  - Replaced manual padding with `consumeWindowInsets` in `NavHostGraph`
  - Restructured `AppNavBar` to properly handle system bars with `navigationBarsPadding`

- **Window Insets**:
  - Added proper status bar padding to `TopBar` component
  - Implemented navigation bar padding in screens like `LoginScreen`, `WelcomeScreen`, and `FooterSection`
  - Replaced deprecated `systemBarsPadding` with explicit `WindowInsets.systemBars` handling

- **UI Components**:
  - Consolidated top bar modifiers into a single `detailsTopBar` extension
  - Improved footer section animations and padding behavior
  - Fixed layout issues in onboarding screens

These changes improve system bar behavior consistency and simplify inset handling across the app.


### Development

Closes #696
