### PR TITLE
feat: Add Background Gradient to Screens

### DIFF
--- a/presentation/src/main/java/com/london/presentation/feature/account/AccountScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/account/AccountScreen.kt
@@ -1,14 +1,18 @@
 package com.london.presentation.feature.account
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.TopBar
@@ -19,6 +23,7 @@ import com.london.presentation.feature.account.bottomsheet.LanguageBottomSheet
 import com.london.presentation.feature.account.bottomsheet.LogoutBottomSheet
 import com.london.presentation.feature.account.components.LoggedInContent
 import com.london.presentation.feature.account.components.NotLoggedInContent
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
 import com.london.presentation.utils.navBarBottomPadding
@@ -61,61 +66,70 @@ private fun Content(
     uiState: AccountUiState,
     accountContract: AccountContract,
 ) {
-    Column(Modifier.navBarBottomPadding()) {
-        TopBar(
-            title = stringResource(R.string.my_account),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
 
-        if (uiState.isUserLoggedIn) {
-            LoggedInContent(
-                uiState = uiState,
-                accountContract = accountContract
+        Column(Modifier.navBarBottomPadding()) {
+            TopBar(
+                title = stringResource(R.string.my_account),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
             )
-        } else {
-            NotLoggedInContent(
-                onLoginClick = accountContract::onLoginClick
-            )
-        }
-    }
 
-    when (uiState.activeBottomSheet) {
-        ActiveBottomSheet.Logout -> {
-            LogoutBottomSheet(
-                onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
-                onLogoutConfirmed = accountContract::onLogoutConfirmed,
-                isLoading = uiState.isLogoutLoading
-            )
+            if (uiState.isUserLoggedIn) {
+                LoggedInContent(
+                    uiState = uiState,
+                    accountContract = accountContract
+                )
+            } else {
+                NotLoggedInContent(
+                    onLoginClick = accountContract::onLoginClick
+                )
+            }
         }
 
-        ActiveBottomSheet.ContentRestriction -> {
-            ContentRestrictionBottomSheet(
-                currentLevel = uiState.currentContentRestriction,
-                onSaveClick = accountContract::onContentRestrictionSave,
-                onDismiss = accountContract::onBottomSheetDismiss
-            )
-        }
+        when (uiState.activeBottomSheet) {
+            ActiveBottomSheet.Logout -> {
+                LogoutBottomSheet(
+                    onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
+                    onLogoutConfirmed = accountContract::onLogoutConfirmed,
+                    isLoading = uiState.isLogoutLoading
+                )
+            }
 
-        ActiveBottomSheet.Appearance -> {
-            AppearanceBottomSheet(
-                appTheme = uiState.appTheme,
-                onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
-                onDarkModeSelected = accountContract::onDarkModeSelected,
-                onLightModeSelected = accountContract::onLightModeSelected,
-                onAppearanceModeSave = accountContract::onAppearanceModeSave,
-            )
-        }
+            ActiveBottomSheet.ContentRestriction -> {
+                ContentRestrictionBottomSheet(
+                    currentLevel = uiState.currentContentRestriction,
+                    onSaveClick = accountContract::onContentRestrictionSave,
+                    onDismiss = accountContract::onBottomSheetDismiss
+                )
+            }
 
-        ActiveBottomSheet.Language -> {
-            LanguageBottomSheet(
-                appLanguage = uiState.appLanguage,
-                onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
-                onEnglishSelected = accountContract::onEnglishSelected,
-                onArabicSelected = accountContract::onArabicSelected,
-                onLanguageSettingsSave = accountContract::onLanguageSettingsSave,
-            )
-        }
+            ActiveBottomSheet.Appearance -> {
+                AppearanceBottomSheet(
+                    appTheme = uiState.appTheme,
+                    onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
+                    onDarkModeSelected = accountContract::onDarkModeSelected,
+                    onLightModeSelected = accountContract::onLightModeSelected,
+                    onAppearanceModeSave = accountContract::onAppearanceModeSave,
+                )
+            }
 
-        else -> {}
+            ActiveBottomSheet.Language -> {
+                LanguageBottomSheet(
+                    appLanguage = uiState.appLanguage,
+                    onBottomSheetDismiss = accountContract::onBottomSheetDismiss,
+                    onEnglishSelected = accountContract::onEnglishSelected,
+                    onArabicSelected = accountContract::onArabicSelected,
+                    onLanguageSettingsSave = accountContract::onLanguageSettingsSave,
+                )
+            }
+
+            else -> {}
+        }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/account/rating/MyRatingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/account/rating/MyRatingScreen.kt
@@ -1,6 +1,7 @@
 package com.london.presentation.feature.account.rating
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,9 +11,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.NovixChip
@@ -21,6 +24,7 @@ import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.theme.ThemePreviews
 import com.london.domain.entity.shared.MediaType
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.EmptyGenreLayout
 import com.london.presentation.shared.SnackBarAnimation
 import com.london.presentation.shared.base.ErrorState
@@ -76,54 +80,65 @@ private fun Content(
         onBack = contract::onBackClick,
         onRetry = contract::onRetryClick
     ) {
-        Column(
+
+        Box(
             modifier = Modifier.fillMaxSize()
         ) {
-            TopBar(
+            BackgroundGradient(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                title = stringResource(R.string.my_rating),
-                onBackClick = contract::onBackClick
+                    .align(Alignment.TopStart)
+                    .zIndex(1f)
             )
 
-            RatingChipsRow(
-                selected = selectedCategory,
-                onSelect = contract::onRatingCategorySelected,
-                modifier = Modifier.padding(bottom = 12.dp)
-            )
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                TopBar(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    title = stringResource(R.string.my_rating),
+                    onBackClick = contract::onBackClick
+                )
 
-            if (items.isEmpty()) {
-                EmptyGenreLayout(
-                    message = stringResource(R.string.there_is_no_items),
-                    modifier = Modifier.fillMaxSize()
+                RatingChipsRow(
+                    selected = selectedCategory,
+                    onSelect = contract::onRatingCategorySelected,
+                    modifier = Modifier.padding(bottom = 12.dp)
                 )
-            } else {
-                MediaLazyVerticalGrid(
-                    items = items,
-                    imageUrl = { it.posterPath },
-                    name = { it.title },
-                    rate = { rated -> rated.rating.toLocalizedNumbers() },
-                    hasSaveIcon = false,
-                    isItemSaved = { false },
-                    onSaveClick = {},
-                    onDeleteClick = { rated ->
-                        when (rated.mediaType) {
-                            MediaType.Movie -> contract.onDeleteMovieClick(rated.id)
-                            MediaType.TvShow -> contract.onDeleteTVShowClick(rated.id)
+
+                if (items.isEmpty()) {
+                    EmptyGenreLayout(
+                        message = stringResource(R.string.there_is_no_items),
+                        modifier = Modifier.fillMaxSize()
+                    )
+                } else {
+                    MediaLazyVerticalGrid(
+                        items = items,
+                        imageUrl = { it.posterPath },
+                        name = { it.title },
+                        rate = { rated -> rated.rating.toLocalizedNumbers() },
+                        hasSaveIcon = false,
+                        isItemSaved = { false },
+                        onSaveClick = {},
+                        onDeleteClick = { rated ->
+                            when (rated.mediaType) {
+                                MediaType.Movie -> contract.onDeleteMovieClick(rated.id)
+                                MediaType.TvShow -> contract.onDeleteTVShowClick(rated.id)
+                            }
+                        },
+                        onItemClick = { rated ->
+                            when (rated.mediaType) {
+                                MediaType.Movie -> contract.onMovieClick(rated.id)
+                                MediaType.TvShow -> contract.onTvShowClick(rated.id)
+                            }
                         }
-                    },
-                    onItemClick = { rated ->
-                        when (rated.mediaType) {
-                            MediaType.Movie -> contract.onMovieClick(rated.id)
-                            MediaType.TvShow -> contract.onTvShowClick(rated.id)
-                        }
-                    }
-                )
+                    )
+                }
             }
-        }
 
-        RatingSnackBar(state)
+            RatingSnackBar(state)
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/authentication/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/authentication/login/LoginScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.Icon
@@ -39,6 +40,7 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.component.button.PrimaryButton
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.SnackBarAnimation
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.utils.Listen
@@ -85,6 +87,11 @@ private fun Content(
             .background(NovixTheme.colors.surface)
             .padding(WindowInsets.navigationBars.asPaddingValues()),
     ) {
+
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+        )
+
         Image(
             painter = painterResource(dsR.drawable.polygon1),
             contentDescription = stringResource(R.string.app_icon),

--- a/presentation/src/main/java/com/london/presentation/feature/category/main/CategoriesScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/main/CategoriesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,9 +20,11 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.NovixChip
@@ -29,6 +32,7 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
 import com.london.designsystem.utils.string
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.CategoriesItem
 import com.london.presentation.shared.MediaCategory
 import com.london.presentation.shared.genre.MovieGenreUi
@@ -64,23 +68,32 @@ private fun Content(
     state: CategoriesUiState,
     contract: CategoriesContract,
 ) {
-    Column(Modifier.navBarBottomPadding()) {
-        TopBar(
-            title = stringResource(R.string.categories),
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
-        CategoriesSelection(
-            onClick = contract::onCategoryClick,
-            selectedCategory = state.selectedCategory,
-            modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
-        )
-        GenresGrid(
-            state = state,
-            contract = contract,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
-        )
+
+        Column(Modifier.navBarBottomPadding()) {
+            TopBar(
+                title = stringResource(R.string.categories),
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            )
+            CategoriesSelection(
+                onClick = contract::onCategoryClick,
+                selectedCategory = state.selectedCategory,
+                modifier = Modifier.padding(top = 12.dp, bottom = 8.dp),
+            )
+            GenresGrid(
+                state = state,
+                contract = contract,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/category/movie/MovieCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/movie/MovieCategoryScreen.kt
@@ -1,5 +1,6 @@
 package com.london.presentation.feature.category.movie
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,9 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -17,6 +20,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -63,39 +67,46 @@ private fun Content(
         emptyLayoutImage = R.drawable.empty
     ) {
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 12.dp)
-        ) {
-            TopBar(
-                title = stringResource(
-                    state.genre.stringResId
-                ),
-                onBackClick = contract::onBack,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ){
+            BackgroundGradient(
+                modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
             )
 
-            MediaLazyPagingGrid(
-                pagingFlow = moviesLazyList,
-                onItemClick = { contract.onMovieClick(it.id) },
-                getImageUrl = { it.posterUrl },
-                getTitle = { "${it.name} movie img" },
+            Column(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                onSaveClick = { contract.onManageBookmarkClicked(it.id) },
-                isItemSaved = { false },
-                hasSaveIcon = true
-            )
+                    .fillMaxSize()
+                    .padding(top = 12.dp)
+            ) {
+                TopBar(
+                    title = stringResource(
+                        state.genre.stringResId
+                    ),
+                    onBackClick = contract::onBack,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+                )
 
-            BookmarkBottomSheet(
-                onSheetDismiss = contract::onBookmarkSheetDismiss,
-                isSheetVisible = state.isBookmarkSheetVisible,
-                bookmarkedMovieId = state.bookmarkedMovieId
-            )
+                MediaLazyPagingGrid(
+                    pagingFlow = moviesLazyList,
+                    onItemClick = { contract.onMovieClick(it.id) },
+                    getImageUrl = { it.posterUrl },
+                    getTitle = { "${it.name} movie img" },
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    onSaveClick = { contract.onManageBookmarkClicked(it.id) },
+                    isItemSaved = { false },
+                    hasSaveIcon = true
+                )
 
+                BookmarkBottomSheet(
+                    onSheetDismiss = contract::onBookmarkSheetDismiss,
+                    isSheetVisible = state.isBookmarkSheetVisible,
+                    bookmarkedMovieId = state.bookmarkedMovieId
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/category/tvshow/TvShowCategoryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/category/tvshow/TvShowCategoryScreen.kt
@@ -1,5 +1,6 @@
 package com.london.presentation.feature.category.tvshow
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -7,9 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -17,6 +20,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.ThemePreviews
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
@@ -62,31 +66,39 @@ private fun Content(
         emptyLayoutImage = R.drawable.empty
     ) {
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(top = 12.dp)
-        ) {
-            TopBar(
-                title = stringResource(
-                    state.genre.stringResId
-                ),
-                onBackClick = contract::onBack,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ){
+            BackgroundGradient(
+                modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
             )
 
-            MediaLazyPagingGrid(
-                pagingFlow = tvShowLazyList,
-                onItemClick = { contract.onTvShowClick(it.id) },
-                getImageUrl = { it.posterPicture },
-                getTitle = { "${it.name} tv show img" },
+            Column(
                 modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                onSaveClick = { /* TODO: Implement save functionality */ },
-                isItemSaved = { false },
-            )
+                    .fillMaxSize()
+                    .padding(top = 12.dp)
+            ) {
+                TopBar(
+                    title = stringResource(
+                        state.genre.stringResId
+                    ),
+                    onBackClick = contract::onBack,
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 12.dp)
+                )
+
+                MediaLazyPagingGrid(
+                    pagingFlow = tvShowLazyList,
+                    onItemClick = { contract.onTvShowClick(it.id) },
+                    getImageUrl = { it.posterPicture },
+                    getTitle = { "${it.name} tv show img" },
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    onSaveClick = { /* TODO: Implement save functionality */ },
+                    isItemSaved = { false },
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/ActorDetailsScreen.kt
@@ -52,6 +52,7 @@ import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.actor.ActorMediaItems
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.HomeCard
@@ -124,6 +125,11 @@ private fun Content(
             .fillMaxSize()
             .background(NovixTheme.colors.surface)
     ) {
+
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+        )
+
         EmptyScreen(uiState)
 
         LazyColumn(

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/info/gallery/ActorsGalleryScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/info/gallery/ActorsGalleryScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.CircularLoading
@@ -29,6 +30,7 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ImageView
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
@@ -61,24 +63,34 @@ private fun Content(
     uiState: ActorsGalleryUiState,
     actorsGalleryContract: ActorsGalleryContract
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(NovixTheme.colors.surface)
-            .navigationBarsPadding()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-    ) {
-        TopBar(
-            modifier = Modifier.padding(bottom = 16.dp),
-            title = stringResource(R.string.gallery),
-            onBackClick = actorsGalleryContract::onBackClick
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+
+        BackgroundGradient(
+            modifier = Modifier.fillMaxSize().align(Alignment.TopStart).zIndex(1f)
         )
 
-        Box(modifier = Modifier.weight(1f)) {
-            if (uiState.isLoading) {
-                CircularLoading(modifier = Modifier.align(Alignment.Center))
-            } else {
-                GalleryContent(uiState = uiState)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(NovixTheme.colors.surface)
+                .navigationBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            TopBar(
+                modifier = Modifier.padding(bottom = 16.dp),
+                title = stringResource(R.string.gallery),
+                onBackClick = actorsGalleryContract::onBackClick
+            )
+
+            Box(modifier = Modifier.weight(1f)) {
+                if (uiState.isLoading) {
+                    CircularLoading(modifier = Modifier.align(Alignment.Center))
+                } else {
+                    GalleryContent(uiState = uiState)
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/info/topmoviespicks/TopMoviesPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/info/topmoviespicks/TopMoviesPicksScreen.kt
@@ -1,12 +1,18 @@
 package com.london.presentation.feature.details.actor.info.topmoviespicks
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
@@ -47,20 +53,29 @@ private fun Content(
         isError = state.errorState is ErrorState.NoInternet,
         onRetry = contract::onRetryClick,
     ) {
-        MediaLazyGrid(
-            title = stringResource(R.string.top_movies_picks),
-            items = state.movieDetails.mediaItems,
-            onBack = contract::onBackClick,
-            getImageUrl = { it.posterUrl },
-            onItemClick = { contract.onMovieClick(it.id) },
-            onSavedClick = { contract.onManageBookmarkClicked(it.id) },
-            hasSaveIcon = true
-        )
 
-        BookmarkBottomSheet(
-            onSheetDismiss = contract::onBookmarkSheetDismiss,
-            isSheetVisible = state.isBookmarkSheetVisible,
-            bookmarkedMovieId = state.bookmarkedMovieId
-        )
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ){
+
+            BackgroundGradient(
+                modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+            )
+            MediaLazyGrid(
+                title = stringResource(R.string.top_movies_picks),
+                items = state.movieDetails.mediaItems,
+                onBack = contract::onBackClick,
+                getImageUrl = { it.posterUrl },
+                onItemClick = { contract.onMovieClick(it.id) },
+                onSavedClick = { contract.onManageBookmarkClicked(it.id) },
+                hasSaveIcon = true
+            )
+
+            BookmarkBottomSheet(
+                onSheetDismiss = contract::onBookmarkSheetDismiss,
+                isSheetVisible = state.isBookmarkSheetVisible,
+                bookmarkedMovieId = state.bookmarkedMovieId
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/actor/info/toptvshowspicks/TopTvShowsPicksScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/actor/info/toptvshowspicks/TopTvShowsPicksScreen.kt
@@ -1,12 +1,18 @@
 package com.london.presentation.feature.details.actor.info.toptvshowspicks
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.MediaLazyGrid
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -45,12 +51,21 @@ private fun Content(
         isError = state.errorState is ErrorState.NoInternet,
         onRetry = contract::onRetryClick
     ) {
-        MediaLazyGrid(
-            title = stringResource(R.string.top_tv_shows_picks),
-            items = state.tvShowDetails.mediaItems,
-            onBack = contract::onBackClick,
-            getImageUrl = { it.posterUrl },
-            onItemClick = { contract.onTvShowClick(it.id) }
-        )
+
+        Box(
+            modifier = Modifier.fillMaxSize()
+        ){
+            BackgroundGradient(
+                modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+            )
+
+            MediaLazyGrid(
+                title = stringResource(R.string.top_tv_shows_picks),
+                items = state.tvShowDetails.mediaItems,
+                onBack = contract::onBackClick,
+                getImageUrl = { it.posterUrl },
+                onItemClick = { contract.onTvShowClick(it.id) }
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/movie/MovieDetailsScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.R
@@ -63,6 +64,7 @@ import com.london.presentation.R.string.more_like_this
 import com.london.presentation.R.string.overview
 import com.london.presentation.R.string.view_reviews
 import com.london.presentation.shared.ActorItem
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.FooterSection
@@ -157,6 +159,10 @@ private fun Content(
             .fillMaxSize()
             .background(NovixTheme.colors.surface)
     ) {
+
+        BackgroundGradient(
+            modifier = Modifier.fillMaxSize().align(Alignment.TopStart).zIndex(2f)
+        )
 
         TopBar(
             onBackClick = contract::onBackClick,

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episode/EpisodeDetailScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/episode/EpisodeDetailScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.component.GuestUserLoginBottomSheet
@@ -44,6 +45,7 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
 import com.london.presentation.shared.ActorItem
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.FooterSection
@@ -120,6 +122,11 @@ private fun Content(
             .fillMaxSize()
             .background(NovixTheme.colors.surface)
     ) {
+
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(2f)
+        )
+
         TopBar(
             onBackClick = contract::onBackClick,
             modifier = Modifier.detailsTopBar(backgroundAlpha),

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.R
@@ -62,6 +63,7 @@ import com.london.domain.entity.shared.MediaType
 import com.london.domain.entity.tvshow.cast.TvShowCastMember
 import com.london.domain.entity.tvshow.episode.Episodes
 import com.london.presentation.shared.ActorItem
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.CustomBackDropImagePager
 import com.london.presentation.shared.FooterSection
@@ -165,6 +167,10 @@ private fun Content(
             onBackClick = tvShowDetailsContract::onBackClicked,
             modifier = Modifier.detailsTopBar(backgroundAlpha),
             option1Icon = R.drawable.icon_remove,
+        )
+
+        BackgroundGradient(
+            modifier = Modifier.fillMaxSize().align(Alignment.TopStart).zIndex(1f)
         )
 
         LazyColumn(

--- a/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/details/tvshow/info/TvShowDetailScreen.kt
@@ -70,6 +70,7 @@ import com.london.presentation.shared.FooterSection
 import com.london.presentation.shared.ImageView
 import com.london.presentation.shared.RatingItem
 import com.london.presentation.shared.SnackBarAnimation
+import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.shared.genre.TvShowGenreUi
 import com.london.presentation.utils.Listen
@@ -122,7 +123,7 @@ fun TvShowsDetailsScreen(
     BuildScreen(
         onBack = viewModel::onBackClicked,
         isLoading = uiState.isLoading,
-        isError = uiState.error != null,
+        isError = uiState.error is ErrorState.NoInternet,
         onRetry = viewModel::onRetry
     ) {
         Content(

--- a/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/HomeScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidth
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -30,13 +29,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
@@ -56,6 +53,7 @@ import com.london.presentation.feature.home.trending.TrendingSection
 import com.london.presentation.feature.home.upcoming.UpcomingMovieItem
 import com.london.presentation.feature.home.upcoming.UpcomingSectionTitle
 import com.london.presentation.feature.home.upcoming.UpcomingStickyHeader
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.CarousalShimmerEffect
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
 import com.london.presentation.shared.buildscreen.NetworkErrorScreen
@@ -186,8 +184,7 @@ private fun HomeScreenLayout(
         modifier = Modifier.fillMaxSize().navBarBottomPadding()
     ) {
         BackgroundGradient(
-            screenWidth = screenWidth,
-            modifier = Modifier.align(Alignment.TopStart)
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
 
         Column(modifier = Modifier.fillMaxSize()) {
@@ -222,26 +219,6 @@ private fun HomeScreenLayout(
     )
 }
 
-@Composable
-private fun BackgroundGradient(
-    screenWidth: Dp,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .size(400.dp)
-            .background(
-                Brush.linearGradient(
-                    colors = listOf(
-                        NovixTheme.colors.primary.copy(alpha = 0.09f),
-                        Color.Transparent
-                    ),
-                    start = Offset(0f, 0f),
-                    end = Offset(screenWidth.value, 400f)
-                )
-            )
-    )
-}
 
 @Composable
 private fun HomeTopBar(modifier: Modifier = Modifier) {

--- a/presentation/src/main/java/com/london/presentation/feature/home/continuewatching/ContinueWatchingScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/continuewatching/ContinueWatchingScreen.kt
@@ -1,18 +1,22 @@
 package com.london.presentation.feature.home.continuewatching
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.movie.Movie
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.DefaultAppTopBar
 import com.london.presentation.shared.MediaCategory
 import com.london.presentation.shared.base.ErrorState
@@ -66,44 +70,54 @@ private fun Content(
     contract: ContinueWatchingContract,
     screenTitle: String = stringResource(R.string.continue_watch)
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = NovixTheme.colors.surface)
-    ) {
-        MediaLazyGridWithTabs(
-            items = getCombinedItems(state),
-            tabSelected = getSelectedTabIndex(state),
-            onTabSelected = contract::onMediaCategoryTabClick,
-            onMovieGenreClick = contract::onMovieGenreClick,
-            onTvShowGenreClick = contract::onTvShowGenreClick,
-            config = MediaGridConfig(
-                showSaveIcon = state.selectedMediaCategory == MediaCategory.Movies,
-                isDarkMode = NovixTheme.isThemeDark,
-                selectedMovieGenre = state.selectedMovieGenre,
-                selectedTvShowGenre = state.selectedTvShowGenre,
-                isMovieSelected = MediaCategory.Movies == state.selectedMediaCategory,
-                isTvShowSelected = MediaCategory.TvShows == state.selectedMediaCategory,
-                onNavigateToMovie = contract::onNavigateToMovieClick,
-                onNavigateToTvShow = contract::onNavigateToTvShowClick,
-                onSaveClick = { if (it is Movie) contract.onManageBookmarkClicked(it.id) },
-                isItemSaved = { false },
-                rate = null
-            ),
-            topBar = {
-                DefaultAppTopBar(
-                    title = screenTitle,
-                    onBack = contract::onBackClick
-                )
-            },
-            isLoading = state.isLoading
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
 
-        BookmarkBottomSheet(
-            onSheetDismiss = contract::onBookmarkSheetDismiss,
-            isSheetVisible = state.isBookmarkSheetVisible,
-            bookmarkedMovieId = state.bookmarkedMovieId
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = NovixTheme.colors.surface)
+        ) {
+            MediaLazyGridWithTabs(
+                items = getCombinedItems(state),
+                tabSelected = getSelectedTabIndex(state),
+                onTabSelected = contract::onMediaCategoryTabClick,
+                onMovieGenreClick = contract::onMovieGenreClick,
+                onTvShowGenreClick = contract::onTvShowGenreClick,
+                config = MediaGridConfig(
+                    showSaveIcon = state.selectedMediaCategory == MediaCategory.Movies,
+                    isDarkMode = NovixTheme.isThemeDark,
+                    selectedMovieGenre = state.selectedMovieGenre,
+                    selectedTvShowGenre = state.selectedTvShowGenre,
+                    isMovieSelected = MediaCategory.Movies == state.selectedMediaCategory,
+                    isTvShowSelected = MediaCategory.TvShows == state.selectedMediaCategory,
+                    onNavigateToMovie = contract::onNavigateToMovieClick,
+                    onNavigateToTvShow = contract::onNavigateToTvShowClick,
+                    onSaveClick = { if (it is Movie) contract.onManageBookmarkClicked(it.id) },
+                    isItemSaved = { false },
+                    rate = null
+                ),
+                topBar = {
+                    DefaultAppTopBar(
+                        title = screenTitle,
+                        onBack = contract::onBackClick
+                    )
+                },
+                isLoading = state.isLoading
+            )
+
+            BookmarkBottomSheet(
+                onSheetDismiss = contract::onBookmarkSheetDismiss,
+                isSheetVisible = state.isBookmarkSheetVisible,
+                bookmarkedMovieId = state.bookmarkedMovieId
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/toprated/TopRatedScreen.kt
@@ -3,6 +3,7 @@ package com.london.presentation.feature.home.toprated
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -16,12 +17,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -31,6 +34,7 @@ import com.london.designsystem.component.TabLayout
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.designsystem.utils.string
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.HomeCard
 import com.london.presentation.shared.MediaCategory
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
@@ -82,92 +86,104 @@ private fun Content(
 ) {
     val screenWidth =
         with(LocalDensity.current) { LocalWindowInfo.current.containerSize.width.toDp() }
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(color = NovixTheme.colors.surface)
 
+    Box(
+        modifier = Modifier.fillMaxSize()
     ) {
-        TopBar(
+
+        BackgroundGradient(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-                .padding(top = 12.dp),
-            title = com.london.presentation.R.string.top_rated.string,
-            onBackClick = contract::onBackClicked
+                .align(Alignment.TopStart)
+                .zIndex(1f)
         )
 
-        TabLayout(
-            tabs = listOf(
-                MediaCategory.Movies,
-                MediaCategory.TvShows
-            ),
-            selectedTab = state.selectedMediaCategory,
-            onTabSelected = contract::onMediaCategoryTabSelected,
-            modifier = Modifier.background(NovixTheme.colors.surface)
-        )
-        if (state.isMovieSelected)
-            MovieGenreRow(
-                onGenreClick = contract::movieGenre,
-                state = state,
-                screenWidth = screenWidth
-            )
-        else
-            TvShowRow(
-                onGenreClick = contract::tvShowGenre,
-                state = state,
-                screenWidth = screenWidth
-            )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = NovixTheme.colors.surface)
 
-        val moviesPagingItems = state.movies.collectAsLazyPagingItems()
-        val tvSeriesPagingItems = state.tvSeries.collectAsLazyPagingItems()
-
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(gridColumns()),
-            contentPadding = PaddingValues(
-                top = 12.dp, bottom = 16.dp, start = 16.dp, end = 16.dp
-            ),
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-            modifier = Modifier.background(NovixTheme.colors.surface)
         ) {
+            TopBar(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp),
+                title = com.london.presentation.R.string.top_rated.string,
+                onBackClick = contract::onBackClicked
+            )
 
-            if (state.isMovieSelected) {
-                items(moviesPagingItems.itemCount) { index ->
-                    val movie = moviesPagingItems[index]
-                    movie?.let { movieItem ->
+            TabLayout(
+                tabs = listOf(
+                    MediaCategory.Movies,
+                    MediaCategory.TvShows
+                ),
+                selectedTab = state.selectedMediaCategory,
+                onTabSelected = contract::onMediaCategoryTabSelected,
+                modifier = Modifier.background(NovixTheme.colors.surface)
+            )
+            if (state.isMovieSelected)
+                MovieGenreRow(
+                    onGenreClick = contract::movieGenre,
+                    state = state,
+                    screenWidth = screenWidth
+                )
+            else
+                TvShowRow(
+                    onGenreClick = contract::tvShowGenre,
+                    state = state,
+                    screenWidth = screenWidth
+                )
+
+            val moviesPagingItems = state.movies.collectAsLazyPagingItems()
+            val tvSeriesPagingItems = state.tvSeries.collectAsLazyPagingItems()
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(gridColumns()),
+                contentPadding = PaddingValues(
+                    top = 12.dp, bottom = 16.dp, start = 16.dp, end = 16.dp
+                ),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.background(NovixTheme.colors.surface)
+            ) {
+
+                if (state.isMovieSelected) {
+                    items(moviesPagingItems.itemCount) { index ->
+                        val movie = moviesPagingItems[index]
+                        movie?.let { movieItem ->
+                            HomeCard(
+                                imageUrl = movieItem.posterUrl,
+                                isSaved = false,
+                                hasSaveIcon = true,
+                                onSaveClick = { contract.onManageBookmarkClicked(movieItem.id) },
+                                modifier = Modifier.clickable {
+                                    contract.onMovieClick(movieItem.id)
+                                }
+                            )
+                        }
+                    }
+                }
+                items(tvSeriesPagingItems.itemCount) { index ->
+                    val tvSeries = tvSeriesPagingItems[index]
+                    tvSeries?.let { seriesItem ->
                         HomeCard(
-                            imageUrl = movieItem.posterUrl,
+                            imageUrl = seriesItem.posterUrl,
+                            hasSaveIcon = false,
                             isSaved = false,
-                            hasSaveIcon = true,
-                            onSaveClick = { contract.onManageBookmarkClicked(movieItem.id) },
-                            modifier = Modifier.clickable {
-                                contract.onMovieClick(movieItem.id)
-                            }
+                            onSaveClick = {},
+                            modifier = Modifier.clickable { contract.onTvShowClick(seriesItem.id) }
                         )
                     }
                 }
             }
-            items(tvSeriesPagingItems.itemCount) { index ->
-                val tvSeries = tvSeriesPagingItems[index]
-                tvSeries?.let { seriesItem ->
-                    HomeCard(
-                        imageUrl = seriesItem.posterUrl,
-                        hasSaveIcon = false,
-                        isSaved = false,
-                        onSaveClick = {},
-                        modifier = Modifier.clickable { contract.onTvShowClick(seriesItem.id) }
-                    )
-                }
-            }
+
+            BookmarkBottomSheet(
+                onSheetDismiss = contract::onBookmarkSheetDismiss,
+                isSheetVisible = state.isBookmarkSheetVisible,
+                bookmarkedMovieId = state.bookmarkedMovieId
+            )
+
         }
-
-        BookmarkBottomSheet(
-            onSheetDismiss = contract::onBookmarkSheetDismiss,
-            isSheetVisible = state.isBookmarkSheetVisible,
-            bookmarkedMovieId = state.bookmarkedMovieId
-        )
-
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/actor/TrendingActorsScreen.kt
@@ -1,6 +1,7 @@
 package com.london.presentation.feature.home.trending.actor
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -9,10 +10,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -21,6 +24,7 @@ import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
 import com.london.presentation.shared.ActorItem
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.LazyPagingColumn
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
@@ -66,37 +70,46 @@ private fun Content(
     state: TrendingActorsUiState,
     contract: TrendingActorsContract,
 ) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 16.dp)
-            .background(color = NovixTheme.colors.surface),
-        contentPadding = PaddingValues(bottom = 16.dp)
-    ) {
-        stickyHeader {
-            TopBar(
-                title = stringResource(R.string.trending_people),
-                onBackClick = contract::onBackClick,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(NovixTheme.colors.surface)
-                    .padding(vertical = 12.dp)
-            )
-        }
 
-        item {
-            LazyPagingColumn(
-                pagingItems = state.actorsFlow.collectAsLazyPagingItems(),
-                modifier = Modifier.fillMaxSize(),
-                itemContent = { actor ->
-                    ActorItem(
-                        actorName = actor.name,
-                        characterName = null,
-                        imageRes = actor.profilePictureUrl,
-                        onClick = { contract.onActorClick(actor.id) }
-                    )
-                }
-            )
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+        )
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp)
+                .background(color = NovixTheme.colors.surface),
+            contentPadding = PaddingValues(bottom = 16.dp)
+        ) {
+            stickyHeader {
+                TopBar(
+                    title = stringResource(R.string.trending_people),
+                    onBackClick = contract::onBackClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(NovixTheme.colors.surface)
+                        .padding(vertical = 12.dp)
+                )
+            }
+
+            item {
+                LazyPagingColumn(
+                    pagingItems = state.actorsFlow.collectAsLazyPagingItems(),
+                    modifier = Modifier.fillMaxSize(),
+                    itemContent = { actor ->
+                        ActorItem(
+                            actorName = actor.name,
+                            characterName = null,
+                            imageRes = actor.profilePictureUrl,
+                            onClick = { contract.onActorClick(actor.id) }
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/movie/TrendingMoviesScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/movie/TrendingMoviesScreen.kt
@@ -1,6 +1,7 @@
 package com.london.presentation.feature.home.trending.movie
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,18 +9,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.GenresSection
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
@@ -66,45 +70,52 @@ private fun Content(
 ) {
     val screenWidth = with(LocalDensity.current) { LocalConfiguration.current.screenWidthDp.dp }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(NovixTheme.colors.surface)
-    ) {
-        TopBar(
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+        )
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            title = stringResource(R.string.trending_movies),
-            onBackClick = contract::onBackClick
-        )
-        GenresSection(
-            genres = state.movieGenres,
-            selectedGenre = state.selectedGenre,
-            screenWidth = screenWidth,
-            onGenreClick = contract::onGenreClick,
-            modifier = Modifier.padding(bottom = 12.dp),
-            getGenreName = { stringResource(it.stringResId) }
-        )
+                .fillMaxSize()
+                .background(NovixTheme.colors.surface)
+        ) {
+            TopBar(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                title = stringResource(R.string.trending_movies),
+                onBackClick = contract::onBackClick
+            )
+            GenresSection(
+                genres = state.movieGenres,
+                selectedGenre = state.selectedGenre,
+                screenWidth = screenWidth,
+                onGenreClick = contract::onGenreClick,
+                modifier = Modifier.padding(bottom = 12.dp),
+                getGenreName = { stringResource(it.stringResId) }
+            )
 
-        MediaLazyPagingGrid(
-            pagingFlow = state.moviesFlow.collectAsLazyPagingItems(),
-            onItemClick = { contract.onMovieClick(it.id) },
-            getImageUrl = { it.posterPath },
-            getTitle = { it.title },
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            onSaveClick = { contract.onManageBookmarkClicked(it.id) },
-            hasSaveIcon = true
-        )
+            MediaLazyPagingGrid(
+                pagingFlow = state.moviesFlow.collectAsLazyPagingItems(),
+                onItemClick = { contract.onMovieClick(it.id) },
+                getImageUrl = { it.posterPath },
+                getTitle = { it.title },
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                onSaveClick = { contract.onManageBookmarkClicked(it.id) },
+                hasSaveIcon = true
+            )
 
-        BookmarkBottomSheet(
-            onSheetDismiss = contract::onBookmarkSheetDismiss,
-            isSheetVisible = state.isBookmarkSheetVisible,
-            bookmarkedMovieId = state.bookmarkedMovieId
-        )
+            BookmarkBottomSheet(
+                onSheetDismiss = contract::onBookmarkSheetDismiss,
+                isSheetVisible = state.isBookmarkSheetVisible,
+                bookmarkedMovieId = state.bookmarkedMovieId
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshow/TrendingTvShowsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/home/trending/tvshow/TrendingTvShowsScreen.kt
@@ -1,6 +1,7 @@
 package com.london.presentation.feature.home.trending.tvshow
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,12 +9,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -21,6 +24,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.london.designsystem.component.TopBar
 import com.london.designsystem.theme.NovixTheme
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.GenresSection
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -67,38 +71,45 @@ private fun Content(
     val screenWidth = with(LocalDensity.current) { LocalConfiguration.current.screenWidthDp.dp }
     val tvShowsLazyItems = state.tvShowsFlow.collectAsLazyPagingItems()
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(NovixTheme.colors.surface)
-    ) {
-        TopBar(
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
+        )
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            title = stringResource(R.string.trending_tv_shows),
-            onBackClick = contract::onBackClick
-        )
-        GenresSection(
-            genres = state.tvShowsGenres,
-            selectedGenre = state.selectedGenre,
-            screenWidth = screenWidth,
-            onGenreClick = contract::onGenreClick,
-            modifier = Modifier.padding(bottom = 12.dp),
-            getGenreName = { stringResource(it.stringResId) }
-        )
-        MediaLazyPagingGrid(
-            pagingFlow = tvShowsLazyItems,
-            onItemClick = { contract.onTvShowClick(it.id) },
-            getImageUrl = { it.posterPath },
-            getTitle = { it.title },
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            onSaveClick = { /* TODO: Implement save functionality */ },
-            isItemSaved = { false },
-        )
+                .fillMaxSize()
+                .background(NovixTheme.colors.surface)
+        ) {
+            TopBar(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                title = stringResource(R.string.trending_tv_shows),
+                onBackClick = contract::onBackClick
+            )
+            GenresSection(
+                genres = state.tvShowsGenres,
+                selectedGenre = state.selectedGenre,
+                screenWidth = screenWidth,
+                onGenreClick = contract::onGenreClick,
+                modifier = Modifier.padding(bottom = 12.dp),
+                getGenreName = { stringResource(it.stringResId) }
+            )
+            MediaLazyPagingGrid(
+                pagingFlow = tvShowsLazyItems,
+                onItemClick = { contract.onTvShowClick(it.id) },
+                getImageUrl = { it.posterPath },
+                getTitle = { it.title },
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                onSaveClick = { /* TODO: Implement save functionality */ },
+                isItemSaved = { false },
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -50,6 +51,7 @@ import com.london.designsystem.utils.string
 import com.london.domain.entity.movie.MovieList
 import com.london.presentation.R
 import com.london.presentation.feature.list.bottomsheets.AddListBottomSheet
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
 import com.london.presentation.utils.Listen
@@ -94,50 +96,62 @@ private fun Content(
         emptyContent = { EmptyList(contract = contract, addListSheetState = state.addListSheetState) },
         handlePagingLoadingAutomatically = true
     ) {
-        ScreenScaffold(
-            titleRes = R.string.saved_list_title,
-            onFabClick = contract::onFabClick
+
+        Box(
+            modifier = Modifier.fillMaxSize()
         ) {
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+
+            BackgroundGradient(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .zIndex(1f)
+            )
+
+            ScreenScaffold(
+                titleRes = R.string.saved_list_title,
+                onFabClick = contract::onFabClick
             ) {
-                items(pagingItems.itemCount) { index ->
-                    val item = pagingItems[index]
-                    item?.let {
-                        SavedListItemRow(
-                            itemUi = item,
-                            onCountClick = contract::onListClick
-                        )
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    items(pagingItems.itemCount) { index ->
+                        val item = pagingItems[index]
+                        item?.let {
+                            SavedListItemRow(
+                                itemUi = item,
+                                onCountClick = contract::onListClick
+                            )
+                        }
                     }
                 }
+
+                AddListBottomSheet(
+                    addListInteractions = contract,
+                    addListSheetState = state.addListSheetState
+                )
             }
 
-            AddListBottomSheet(
-                addListInteractions = contract,
-                addListSheetState = state.addListSheetState
-            )
-        }
+            val snackBarController = LocalSnackbarController.current
 
-        val snackBarController = LocalSnackbarController.current
+            if (state.error != null) {
+                snackBarController.showMessage(
+                    message = R.string.list_added_fail.string,
+                    snackBarType = SnackBarType.Error,
+                    onComplete = contract::resetSnackBarErrorState,
+                    icon = null,
+                )
+            }
 
-        if (state.error != null) {
-            snackBarController.showMessage(
-                message = R.string.list_added_fail.string,
-                snackBarType = SnackBarType.Error,
-                onComplete = contract::resetSnackBarErrorState,
-                icon = null,
-            )
-        }
-
-        if (state.isSnackBarSuccessVisible) {
-            snackBarController.showMessage(
-                message = R.string.list_added_success.string,
-                snackBarType = SnackBarType.Success,
-                onComplete = contract::resetSnackBarSuccessState,
-                icon = com.london.designsystem.R.drawable.ic_success,
-            )
+            if (state.isSnackBarSuccessVisible) {
+                snackBarController.showMessage(
+                    message = R.string.list_added_success.string,
+                    snackBarType = SnackBarType.Success,
+                    onComplete = contract::resetSnackBarSuccessState,
+                    icon = com.london.designsystem.R.drawable.ic_success,
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/savedlist/ListScreen.kt
@@ -86,26 +86,27 @@ private fun Content(
     contract: ListContract,
 ) {
     val pagingItems = state.items.collectAsLazyPagingItems()
-    BuildScreen(
-        onRetry = contract::onRetry,
-        isLoading = state.isLoading,
-        isError = state.error is ErrorState.NoInternet,
-        pagingFlow = pagingItems,
-        isGuest = state.isGuest,
-        guestContent = { NoListFoundAsGuest(onLoginClick = contract::onLoginClick) },
-        emptyContent = { EmptyList(contract = contract, addListSheetState = state.addListSheetState) },
-        handlePagingLoadingAutomatically = true
+
+    Box(
+        modifier = Modifier.fillMaxSize()
     ) {
 
-        Box(
-            modifier = Modifier.fillMaxSize()
-        ) {
+        BackgroundGradient(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .zIndex(1f)
+        )
 
-            BackgroundGradient(
-                modifier = Modifier
-                    .align(Alignment.TopStart)
-                    .zIndex(1f)
-            )
+        BuildScreen(
+            onRetry = contract::onRetry,
+            isLoading = state.isLoading,
+            isError = state.error is ErrorState.NoInternet,
+            pagingFlow = pagingItems,
+            isGuest = state.isGuest,
+            guestContent = { NoListFoundAsGuest(onLoginClick = contract::onLoginClick) },
+            emptyContent = { EmptyList(contract = contract, addListSheetState = state.addListSheetState) },
+            handlePagingLoadingAutomatically = true
+        ) {
 
             ScreenScaffold(
                 titleRes = R.string.saved_list_title,

--- a/presentation/src/main/java/com/london/presentation/feature/list/viewitems/ViewItemsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/list/viewitems/ViewItemsScreen.kt
@@ -1,12 +1,16 @@
 package com.london.presentation.feature.list.viewitems
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -18,6 +22,7 @@ import com.london.designsystem.theme.ThemePreviews
 import com.london.designsystem.utils.string
 import com.london.presentation.R
 import com.london.presentation.feature.list.bottomsheets.DeleteListBottomSheet
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.MediaLazyPagingGrid
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -52,76 +57,85 @@ private fun Content(
     contract: ViewListItemsContract,
 ) {
     val listItems = state.listItems.collectAsLazyPagingItems()
-    Column {
-        TopBar(
-            title = state.listTitle,
-            onBackClick = contract::onBack,
-            option2Icon = R.drawable.ic_delete,
-            onClickOption2 = contract::onDeleteClick,
-            option2IconTint = NovixTheme.colors.redAccent,
-            modifier = Modifier
-                .padding(horizontal = 16.dp, vertical = 12.dp)
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
 
-        BuildScreen(
-            onBack = null,
-            onRetry = listItems::refresh,
-            isLoading = state.isLoading,
-            isError = state.error == ErrorState.NoInternet,
-            emptyLayoutMessage = R.string.no_items_found,
-            emptyLayoutImage = R.drawable.img_no_result,
-            pagingFlow = listItems,
-        ) {
-            MediaLazyPagingGrid(
+        Column {
+            TopBar(
+                title = state.listTitle,
+                onBackClick = contract::onBack,
+                option2Icon = R.drawable.ic_delete,
+                onClickOption2 = contract::onDeleteClick,
+                option2IconTint = NovixTheme.colors.redAccent,
+                modifier = Modifier
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+            )
+
+            BuildScreen(
+                onBack = null,
+                onRetry = listItems::refresh,
+                isLoading = state.isLoading,
+                isError = state.error == ErrorState.NoInternet,
+                emptyLayoutMessage = R.string.no_items_found,
+                emptyLayoutImage = R.drawable.img_no_result,
                 pagingFlow = listItems,
-                modifier = Modifier.padding(horizontal = 16.dp),
-                onItemClick = { contract.onMovieClick(it.id) },
-                getImageUrl = { it.posterUrl },
-                getTitle = { "${it.id} media img" },
-                onSaveClick = {
-                    contract.onRemoveMovieClick(it.id)
-                    contract.onRetry()
-                },
-                isItemSaved = { true },
-                hasSaveIcon = true
+            ) {
+                MediaLazyPagingGrid(
+                    pagingFlow = listItems,
+                    modifier = Modifier.padding(horizontal = 16.dp),
+                    onItemClick = { contract.onMovieClick(it.id) },
+                    getImageUrl = { it.posterUrl },
+                    getTitle = { "${it.id} media img" },
+                    onSaveClick = {
+                        contract.onRemoveMovieClick(it.id)
+                        contract.onRetry()
+                    },
+                    isItemSaved = { true },
+                    hasSaveIcon = true
+                )
+            }
+        }
+
+        DeleteListBottomSheet(
+            isSheetVisible = state.isDeleteBottomSheetVisible,
+            contract = contract,
+        )
+
+        val snackBarController = LocalSnackbarController.current
+
+        if (state.isSnackBarErrorVisible) {
+            snackBarController.showMessage(
+                message = R.string.deletion_failed.string,
+                snackBarType = SnackBarType.Error,
+                onComplete = contract::resetSnackBarErrorState,
+                icon = null,
+            )
+        }
+
+        if (state.isMovieSnackBarSuccessVisible) {
+            snackBarController.showMessage(
+                message = R.string.movie_removed_successfully.string,
+                snackBarType = SnackBarType.Success,
+                onComplete = contract::resetMovieSnackBarSuccessState,
+                icon = com.london.designsystem.R.drawable.ic_success,
+            )
+        }
+
+        if (state.isListSnackBarSuccess) {
+            snackBarController.showMessage(
+                message = R.string.list_removed_successfully.string,
+                snackBarType = SnackBarType.Success,
+                onComplete = contract::resetListSnackBarSuccessState,
+                icon = com.london.designsystem.R.drawable.ic_success,
             )
         }
     }
-
-    DeleteListBottomSheet(
-        isSheetVisible = state.isDeleteBottomSheetVisible,
-        contract = contract,
-    )
-
-    val snackBarController = LocalSnackbarController.current
-
-    if (state.isSnackBarErrorVisible) {
-        snackBarController.showMessage(
-            message = R.string.deletion_failed.string,
-            snackBarType = SnackBarType.Error,
-            onComplete = contract::resetSnackBarErrorState,
-            icon = null,
-        )
-    }
-
-    if (state.isMovieSnackBarSuccessVisible) {
-        snackBarController.showMessage(
-            message = R.string.movie_removed_successfully.string,
-            snackBarType = SnackBarType.Success,
-            onComplete = contract::resetMovieSnackBarSuccessState,
-            icon = com.london.designsystem.R.drawable.ic_success,
-        )
-    }
-
-    if (state.isListSnackBarSuccess) {
-        snackBarController.showMessage(
-            message = R.string.list_removed_successfully.string,
-            snackBarType = SnackBarType.Success,
-            onComplete = contract::resetListSnackBarSuccessState,
-            icon = com.london.designsystem.R.drawable.ic_success,
-        )
-    }
-
 }
 
 @Composable

--- a/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/reviews/ReviewsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.LoadState
@@ -42,6 +43,7 @@ import com.london.designsystem.component.button.ErrorImage
 import com.london.designsystem.theme.NovixTheme
 import com.london.domain.entity.review.Review
 import com.london.presentation.R
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.ConditionalText
 import com.london.presentation.shared.ImageView
 import com.london.presentation.shared.RatingItem
@@ -85,19 +87,28 @@ private fun Content(
     reviewsList: LazyPagingItems<Review>,
     reviewContract: ReviewContract
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(NovixTheme.colors.surface)
-    ) {
-        ReviewsTopBar(
-            onBackClick = reviewContract::onBackClicked
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+    ){
+        BackgroundGradient(
+            modifier = Modifier.align(Alignment.TopStart).zIndex(1f)
         )
 
-        ReviewsContent(
-            reviewsList = reviewsList,
-            modifier = Modifier.weight(1f)
-        )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(NovixTheme.colors.surface)
+        ) {
+            ReviewsTopBar(
+                onBackClick = reviewContract::onBackClicked
+            )
+
+            ReviewsContent(
+                reviewsList = reviewsList,
+                modifier = Modifier.weight(1f)
+            )
+        }
     }
 }
 

--- a/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
+++ b/presentation/src/main/java/com/london/presentation/feature/search/SearchScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -59,8 +60,8 @@ import com.london.domain.entity.shared.MediaType
 import com.london.domain.entity.shared.MediaType.Companion.isMovie
 import com.london.presentation.R
 import com.london.presentation.shared.ActorsLayout
+import com.london.presentation.shared.BackgroundGradient
 import com.london.presentation.shared.HomeCard
-import com.london.presentation.shared.TriangleBlurredShape
 import com.london.presentation.shared.base.ErrorState
 import com.london.presentation.shared.bookmarkSheet.BookmarkBottomSheet
 import com.london.presentation.shared.buildscreen.BuildScreen
@@ -148,7 +149,13 @@ private fun SearchMainContent(
             .navBarBottomPadding()
             .pointerInput(Unit) { detectTapGestures(onTap = { onClearFocus() }) }
     ) {
-        TriangleBlurredShape()
+
+        BackgroundGradient(
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .zIndex(1f)
+        )
+
         Column(
             modifier = Modifier
                 .fillMaxSize()

--- a/presentation/src/main/java/com/london/presentation/shared/BackgroundGradient.kt
+++ b/presentation/src/main/java/com/london/presentation/shared/BackgroundGradient.kt
@@ -1,0 +1,44 @@
+package com.london.presentation.shared
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.unit.IntSize
+import com.london.designsystem.theme.NovixTheme
+
+@Composable
+fun BackgroundGradient(
+    modifier: Modifier = Modifier
+) {
+    var boxSize by remember { mutableStateOf(IntSize.Zero) }
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .onGloballyPositioned { coordinates ->
+                boxSize = coordinates.size
+            }
+            .background(
+                brush = Brush.linearGradient(
+                    colors = listOf(
+                        NovixTheme.colors.primary.copy(alpha = 0.08f),
+                        Color.Transparent,
+                        Color.Transparent,
+                        NovixTheme.colors.primary.copy(alpha = 0.04f),
+                    ),
+                    start = Offset(0f, 0f),
+                    end = Offset(boxSize.width.toFloat(), boxSize.height.toFloat())
+                )
+            )
+    )
+}


### PR DESCRIPTION
# What does this PR do?
This PR introduces a `BackgroundGradient` composable and applies it to various screens across the application. The gradient adds a subtle visual enhancement to the user interface.

- Created `BackgroundGradient.kt` with a composable function that draws a linear gradient.
- Integrated `BackgroundGradient` into the following screens:
    - `EpisodeDetailScreen`
    - `ListScreen`
    - `LoginScreen`
    - `ContinueWatchingScreen`
    - `TopMoviesPicksScreen`
    - `TvShowDetailScreen`
    - `ActorDetailsScreen`
    - `MovieCategoryScreen`
    - `AccountScreen`
    - `ActorsGalleryScreen`
    - `TopTvShowsPicksScreen`
    - `MovieDetailsScreen`
    - `ViewItemsScreen`
    - `TopRatedScreen`
    - `SearchScreen`
    - `HomeScreen`
    - `MyRatingScreen`
    - `CategoriesScreen`
    - `ReviewsScreen`
    - `TvShowCategoryScreen`
    - `Trending screens`
- Adjusted z-index where necessary to ensure the gradient appears behind other UI elements.

## Type of Change
- [x] ✨ New feature
- [x] 🔧 Refactoring
- [x] 🎨 UI changes

## Changes Made
- [x] Compose UI

## Checklist
- [x] Ready for review
